### PR TITLE
[Fix] loadUser()에서 readOnly=true 제거

### DIFF
--- a/src/main/java/me/rentsignal/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/me/rentsignal/global/security/CustomOAuth2UserService.java
@@ -32,7 +32,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final AuthService authService;
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         // 1. provider에서 사용자 정보 (attributes) 조회
         OAuth2User oAuth2User = super.loadUser(userRequest);


### PR DESCRIPTION
## ✅ 관련 이슈
closed #5 

## ✨ 작업 내용
### **상황**
로그인 후 500 에러 발생
... JpaSystemException: could not execute statement Connection is read-only. Queries leading to data modification are not allowed

### **원인**
다른 오류 해결 과정에서 불필요하게 loadUser() 메서드의 @ Transactional에 readOnly=true 옵션 추가
 -> 현재 loadUser() 메서드에서는 createUserWithSocialAccount()를 통해 User와 UserSocialAccount 객체를 **생성하고 저장**하는 로직이 있기 때문에 **readOnly=true**와 충돌

- 구현 과정에서 이 오류를 발견하지 못한 이유
현재 로직은 이미 기존에 해당 소셜 계정으로 로그인한 경우 조회만, 새로운 소셜 계정으로 로그인한 경우 새로 객체를 생성하고 저장하도록 되어있습니다.
-> 기존 제 네이버 계정으로 생성된 User가 있어서 조회만 하고 새로 객체를 저장하는 흐름 (오류가 발생한 흐름)이 없었기 때문에 해당 오류를 발견하지 못하였습니다.

### **해결**
loadUser() 메서드의 @ Transactional에서 readOnly=true 제거


## 📸 스크린샷


## 🗨️ 참고 사항
