### PR TITLE
[Fix] OAuth2 로그인 과정에서 생성된 세션 무효화

### DIFF
--- a/src/main/java/me/rentsignal/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/me/rentsignal/global/security/OAuth2LoginSuccessHandler.java
@@ -1,9 +1,9 @@
 package me.rentsignal.global.security;
 
-import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.user.dto.TokenDto;
 import me.rentsignal.user.service.TokenService;
@@ -48,7 +48,14 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         cookieUtil.addCookie(response, "refreshToken", tokens.getRefreshToken(),
                 (int) (JwtProvider.EXPIRE_REFRESH / 1000), COOKIE_SECURE, COOKIE_SAMESITE);
 
-        // 4. redirect
+        // 4. OAuth2 로그인 과정에서 생긴 세션 무효화
+        HttpSession session = request.getSession(false);
+        if (session != null)
+            session.invalidate();
+
+        cookieUtil.expireCookie(response, "JSESSIONID", COOKIE_SECURE, COOKIE_SAMESITE);
+
+        // 5. redirect
         getRedirectStrategy().sendRedirect(request, response, REDIRECT_URI);
     }
 

--- a/src/main/java/me/rentsignal/global/security/SecurityConfig.java
+++ b/src/main/java/me/rentsignal/global/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -40,6 +41,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.GET, "/api/community/posts").permitAll()   // 게시글 목록은 전체 접근 허용
                         .requestMatchers( "/api/community/**", "/api/mypage/**").authenticated()


### PR DESCRIPTION
## ✅ 관련 이슈
closed #20 

## ✨ 작업 내용
### **원인**

스프링 시큐리티의 기본 설정은 **세션 기반 인증**을 사용하기 때문에, 별도의 설정이 없으면 서버가 JSESSIONID 세션을 생성하고 인증 정보를 세션에 저장

→ 세션 정책을 별도로 설정하지 않아서 인증 정보가 세션에 저장되었고, 로그아웃 후에도 브라우저에 남아있는 기존 JSESSIONID 세션이 재사용되며 /api/mypage/me 요청이 인증된 사용자로 처리되는 문제 발생

(게다가 스프링 시큐리티 기본 로그아웃 엔드포인트인 /logout을 사용할 경우  세션이 자동 무효화되지만, 현재 /api/auth/logout를 사용하기 때문에 스프링 시큐리티의 기본 로그아웃 로직이 동작하지 않아 자동 무효화도 되지 않았음)

### **해결 과정**

현재 서비스는 JWT 기반 인증 구조를 사용하고 있으므로 세션 생성될 필요 X

→ `SessionCreationPolicy.STATELESS`를 설정하여 스프링 시큐리티가 세션 사용하지 않도록 함

→ 하지만 OAuth2 로그인 시에는 **스프링 시큐리티의 oauth2Login()이 OAuth2 인가 요청 정보를 저장하기 위해 세션 사용**할 수 있음 (`SessionCreationPolicy.STATELESS` 를 넣었어도 OAuth2 로그인 과정에서 필요한 세션까지 완전히 금지하는 것은 X)

→ **OAuth2LoginSuccessHandler에서 JSESSIONID 쿠키를 만료시키고 세션 invalidate**해서 정리하도록 처리
<br>

⇒ 다만 위 방법은 이미 생성된 세션을 사후적으로 제거하는 방식이고, **JSESSIONID가 아예 생기지 않게 하려면 oauth2Login()이 쓰는 AuthorizationRequestRepository를 세션 기반이 아니라 쿠키 기반으로 변경**해야함

현재 다른 기능 구현이 우선이기 때문에 현재는 OAuth2LoginSuccessHandler에서 임시적으로 처리하고, 추후 리팩토링 단계에서 AuthorizationRequestRepository를 쿠키 기반으로 변경할 예정

## 📸 스크린샷


## 🗨️ 참고 사항
