### PR TITLE
[Fix] 사용자 조회 실패 시 USER_NOT_FOUND(404) ErrorCode 적용

### DIFF
--- a/src/main/java/me/rentsignal/community/service/CommunityService.java
+++ b/src/main/java/me/rentsignal/community/service/CommunityService.java
@@ -56,9 +56,7 @@ public class CommunityService {
     public Long createPost(Long userId, PostCreateRequest request) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() ->
-                        new BaseException(ErrorCode.INVALID_INPUT_VALUE, "사용자를 찾을 수 없습니다.")
-                );
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         Post post = Post.builder()
                 .user(user)
@@ -77,9 +75,7 @@ public class CommunityService {
     public Long createComment(Long userId, Long postId, CommentCreateRequest request) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() ->
-                        new BaseException(ErrorCode.INVALID_INPUT_VALUE, "사용자를 찾을 수 없습니다.")
-                );
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() ->
@@ -113,9 +109,7 @@ public class CommunityService {
     public void togglePostLike(Long userId, Long postId) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() ->
-                        new BaseException(ErrorCode.INVALID_INPUT_VALUE, "사용자를 찾을 수 없습니다.")
-                );
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() ->
@@ -147,9 +141,7 @@ public class CommunityService {
     public void toggleCommentLike(Long userId, Long commentId) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() ->
-                        new BaseException(ErrorCode.INVALID_INPUT_VALUE, "사용자를 찾을 수 없습니다.")
-                );
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() ->


### PR DESCRIPTION
## ✅ 관련 이슈
User 관련 오류를 USER_NOT_FOUND 로 변경했습니다.

## ✨ 작업 내용


## 📸 스크린샷


## 🗨️ 참고 사항
