### PR TITLE
[Feat] 권역 / 지수 데이터 저장 구현

### DIFF
--- a/src/main/java/me/rentsignal/data/LegalDongCsvReader.java
+++ b/src/main/java/me/rentsignal/data/LegalDongCsvReader.java
@@ -39,8 +39,14 @@ public class LegalDongCsvReader {
                     continue;
                 }
 
-                // 데이터 형식 - 법정동 코드 / 시도명 / 시군구명 / 읍면동명 / 리명 / 순위 / 생성일자
+                // 데이터 형식 - 법정동 코드 / 시도명 / 시군구명 / 읍면동명 / 리명 / 순위 / 생성일자 / 삭제일자
                 String[] tokens = line.split(",", -1);
+
+                // 삭제 일자가 있는 데이터는 패스
+                String deletedAt = get(tokens, 7);
+                if (hasText(deletedAt)) {
+                    continue;
+                }
 
                 String code = get(tokens, 0);
                 String provinceName = get(tokens, 1);
@@ -66,6 +72,10 @@ public class LegalDongCsvReader {
         if (tokens.length <= index) // 데이터 깨짐 방지
             return "";
         return tokens[index].trim();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
 }

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -6,11 +6,10 @@ import me.rentsignal.data.service.IndexService;
 import me.rentsignal.data.service.LegalDongImportService;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.global.security.CustomPrincipal;
+import me.rentsignal.locationInfo.entity.HousingType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,9 +32,10 @@ public class DataController {
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
-    @PostMapping("/rent-index/apt")
-    public ResponseEntity<?> saveAptRentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        indexService.saveAptRentCompositeIndex(customPrincipal.getId());
+    @PostMapping("/rent-index")
+    public ResponseEntity<?> saveRentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal,
+                                           @RequestParam HousingType housingType) {
+        indexService.saveRentCompositeIndex(customPrincipal.getId(), housingType);
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -1,8 +1,8 @@
 package me.rentsignal.data.controller;
 
 import lombok.RequiredArgsConstructor;
-import me.rentsignal.data.service.DataService;
-import me.rentsignal.data.service.IndexService;
+import me.rentsignal.data.service.RegionDataService;
+import me.rentsignal.data.service.RentIndexService;
 import me.rentsignal.data.service.LegalDongImportService;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.global.security.CustomPrincipal;
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.*;
 public class DataController {
 
     private final LegalDongImportService legalDongImportService;
-    private final DataService dataService;
-    private final IndexService indexService;
+    private final RegionDataService regionDataService;
+    private final RentIndexService rentIndexService;
 
     @PostMapping("/legal-dong")
     public ResponseEntity<?> saveLegalDong(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
@@ -28,14 +28,14 @@ public class DataController {
 
     @PostMapping("/region")
     public ResponseEntity<?> saveRegion(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        dataService.saveRegion(customPrincipal.getId());
+        regionDataService.saveRegion(customPrincipal.getId());
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/rent-index")
     public ResponseEntity<?> saveRentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal,
                                            @RequestParam HousingType housingType) {
-        indexService.saveRentCompositeIndex(customPrincipal.getId(), housingType);
+        rentIndexService.saveRentCompositeIndex(customPrincipal.getId(), housingType);
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -1,6 +1,7 @@
 package me.rentsignal.data.controller;
 
 import lombok.RequiredArgsConstructor;
+import me.rentsignal.data.service.DataService;
 import me.rentsignal.data.service.LegalDongImportService;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.global.security.CustomPrincipal;
@@ -16,10 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class DataController {
 
     private final LegalDongImportService legalDongImportService;
+    private final DataService dataService;
 
     @PostMapping("/legal-dong")
     public ResponseEntity<?> saveLegalDong(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
         legalDongImportService.importLegalDongCsv(customPrincipal.getId());
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+    @PostMapping("/region")
+    public ResponseEntity<?> saveRegion(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        dataService.saveRegion(customPrincipal.getId());
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import me.rentsignal.data.service.RegionDataService;
 import me.rentsignal.data.service.RentIndexService;
 import me.rentsignal.data.service.LegalDongImportService;
+import me.rentsignal.data.service.SentimentIndexService;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.global.security.CustomPrincipal;
 import me.rentsignal.locationInfo.entity.HousingType;
@@ -19,6 +20,7 @@ public class DataController {
     private final LegalDongImportService legalDongImportService;
     private final RegionDataService regionDataService;
     private final RentIndexService rentIndexService;
+    private final SentimentIndexService sentimentIndexService;
 
     @PostMapping("/legal-dong")
     public ResponseEntity<?> saveLegalDong(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
@@ -36,6 +38,12 @@ public class DataController {
     public ResponseEntity<?> saveRentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal,
                                            @RequestParam HousingType housingType) {
         rentIndexService.saveRentCompositeIndex(customPrincipal.getId(), housingType);
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+    @PostMapping("/consumer-sentiment-index")
+    public ResponseEntity<?> saveConsumerSentimentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        sentimentIndexService.saveConsumerSentimentIndex(customPrincipal.getId());
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -1,10 +1,7 @@
 package me.rentsignal.data.controller;
 
 import lombok.RequiredArgsConstructor;
-import me.rentsignal.data.service.RegionDataService;
-import me.rentsignal.data.service.RentIndexService;
-import me.rentsignal.data.service.LegalDongImportService;
-import me.rentsignal.data.service.SentimentIndexService;
+import me.rentsignal.data.service.*;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.global.security.CustomPrincipal;
 import me.rentsignal.locationInfo.entity.HousingType;
@@ -21,6 +18,7 @@ public class DataController {
     private final RegionDataService regionDataService;
     private final RentIndexService rentIndexService;
     private final SentimentIndexService sentimentIndexService;
+    private final SubwayIndexService subwayIndexService;
 
     @PostMapping("/legal-dong")
     public ResponseEntity<?> saveLegalDong(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
@@ -44,6 +42,12 @@ public class DataController {
     @PostMapping("/consumer-sentiment-index")
     public ResponseEntity<?> saveConsumerSentimentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
         sentimentIndexService.saveConsumerSentimentIndex(customPrincipal.getId());
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+    @PostMapping("/subway-accessibility-index")
+    public ResponseEntity<?> saveSubwayAccessibilityIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        subwayIndexService.saveSubwayAccessibilityIndex(customPrincipal.getId());
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -2,6 +2,7 @@ package me.rentsignal.data.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.data.service.DataService;
+import me.rentsignal.data.service.IndexService;
 import me.rentsignal.data.service.LegalDongImportService;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.global.security.CustomPrincipal;
@@ -18,6 +19,7 @@ public class DataController {
 
     private final LegalDongImportService legalDongImportService;
     private final DataService dataService;
+    private final IndexService indexService;
 
     @PostMapping("/legal-dong")
     public ResponseEntity<?> saveLegalDong(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
@@ -28,6 +30,12 @@ public class DataController {
     @PostMapping("/region")
     public ResponseEntity<?> saveRegion(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
         dataService.saveRegion(customPrincipal.getId());
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+    @PostMapping("/rent-index/apt")
+    public ResponseEntity<?> saveAptRentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        indexService.saveAptRentCompositeIndex(customPrincipal.getId());
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/dto/IndexApiResponseDto.java
+++ b/src/main/java/me/rentsignal/data/dto/IndexApiResponseDto.java
@@ -27,11 +27,11 @@ public class IndexApiResponseDto {
 
         // areaName (도심권, 동북권 ..)
         @JsonProperty("CLS_NM")
-        private String areaGroup;
+        private String name;
 
         // (서울>강북지역>도심권)
         @JsonProperty("CLS_FULLNM")
-        private String areaName;
+        private String fullName;
 
         // 값
         @JsonProperty("DTA_VAL")

--- a/src/main/java/me/rentsignal/data/dto/IndexApiResponseDto.java
+++ b/src/main/java/me/rentsignal/data/dto/IndexApiResponseDto.java
@@ -1,0 +1,46 @@
+package me.rentsignal.data.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class IndexApiResponseDto {
+
+    @JsonProperty("SttsApiTblData")
+    private List<SttsApiTblData> sttsApiTblData;
+
+    @Data
+    public static class SttsApiTblData {
+
+        private List<Map<String, Object>> head;
+
+        private List<Row> row;
+
+    }
+
+    @Data
+    public static class Row {
+
+        // areaName (도심권, 동북권 ..)
+        @JsonProperty("CLS_NM")
+        private String areaGroup;
+
+        // (서울>강북지역>도심권)
+        @JsonProperty("CLS_FULLNM")
+        private String areaName;
+
+        // 값
+        @JsonProperty("DTA_VAL")
+        private BigDecimal value;
+
+        // 시점 (YYYYMM)
+        @JsonProperty("WRTTIME_IDTFR_ID")
+        private String date;
+
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/dto/SentimentIndexApiResponseDto.java
+++ b/src/main/java/me/rentsignal/data/dto/SentimentIndexApiResponseDto.java
@@ -1,0 +1,20 @@
+package me.rentsignal.data.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class SentimentIndexApiResponseDto {
+
+    @JsonProperty("PRD_DE")
+    private String date;
+
+    @JsonProperty("C1_NM")
+    private String provinceName;
+
+    @JsonProperty("DT")
+    private BigDecimal value;
+
+}

--- a/src/main/java/me/rentsignal/data/service/DataService.java
+++ b/src/main/java/me/rentsignal/data/service/DataService.java
@@ -1,0 +1,82 @@
+package me.rentsignal.data.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.District;
+import me.rentsignal.location.entity.Province;
+import me.rentsignal.location.entity.Region;
+import me.rentsignal.location.repository.DistrictRepository;
+import me.rentsignal.location.repository.ProvinceRepository;
+import me.rentsignal.location.repository.RegionRepository;
+import me.rentsignal.user.entity.Role;
+import me.rentsignal.user.service.AuthService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DataService {
+
+    private final AuthService authService;
+    private final DistrictRepository districtRepository;
+    private final RegionRepository regionRepository;
+    private final ProvinceRepository provinceRepository;
+
+    @Transactional
+    public void saveRegion(Long userId) {
+        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
+
+        Province province = provinceRepository.findByName("서울특별시").orElseThrow(() ->
+                new BaseException(ErrorCode.PROVINCE_NOT_FOUND, "해당 시/도가 존재하지 않습니다. - 서울특별시"));
+
+        // 서울 > 강북지역 > 도심권
+        Region northCentral = regionRepository.save(
+                Region.builder().areaGroup("강북")
+                .areaName("도심권").build());
+        northCentral.addDistricts(List.of(findDistrictByNameAndProvince("종로구", province),
+                findDistrictByNameAndProvince("중구", province), findDistrictByNameAndProvince("용산구", province)));
+
+        // 서울 > 강북지역 > 동북권
+        Region northNorthEast = regionRepository.save(
+                Region.builder().areaGroup("강북")
+                .areaName("동북권").build());
+        northNorthEast.addDistricts(List.of(findDistrictByNameAndProvince("도봉구", province),
+                findDistrictByNameAndProvince("강북구", province), findDistrictByNameAndProvince("노원구", province),
+                findDistrictByNameAndProvince("성북구", province), findDistrictByNameAndProvince("중랑구", province),
+                findDistrictByNameAndProvince("성동구", province), findDistrictByNameAndProvince("광진구", province)));
+
+        // 서울 > 강북지역 > 서북권
+        Region northNorthWest = regionRepository.save(
+                Region.builder().areaGroup("강북")
+                .areaName("서북권").build());
+        northNorthWest.addDistricts(List.of(findDistrictByNameAndProvince("은평구", province),
+                findDistrictByNameAndProvince("서대문구", province), findDistrictByNameAndProvince("마포구", province)));
+
+        // 서울 > 강남지역 > 서남권
+        Region southSouthWest = regionRepository.save(
+                Region.builder().areaGroup("강남")
+                .areaName("서남권").build());
+        southSouthWest.addDistricts(List.of(findDistrictByNameAndProvince("영등포구", province),
+                findDistrictByNameAndProvince("동작구", province), findDistrictByNameAndProvince("관악구", province),
+                findDistrictByNameAndProvince("금천구", province), findDistrictByNameAndProvince("강서구", province),
+                findDistrictByNameAndProvince("양천구", province), findDistrictByNameAndProvince("구로구", province)));
+
+        // 서울 > 강남지역 > 동남권
+        Region southSouthEast = regionRepository.save(
+                Region.builder().areaGroup("강남")
+                .areaName("동남권").build());
+        southSouthEast.addDistricts(List.of(findDistrictByNameAndProvince("서초구", province),
+                findDistrictByNameAndProvince("강남구", province), findDistrictByNameAndProvince("송파구", province),
+                findDistrictByNameAndProvince("강동구", province)));
+    }
+
+    private District findDistrictByNameAndProvince(String name, Province province) {
+        return districtRepository.findByNameAndProvince(name, province).orElseThrow(() ->
+                new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 시/군/구를 찾을 수 없습니다. - " + province.getName() + " " + name)
+        );
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/service/IndexService.java
+++ b/src/main/java/me/rentsignal/data/service/IndexService.java
@@ -1,0 +1,151 @@
+package me.rentsignal.data.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.rentsignal.data.dto.IndexApiResponseDto;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.Region;
+import me.rentsignal.location.repository.RegionRepository;
+import me.rentsignal.locationInfo.entity.HousingType;
+import me.rentsignal.locationInfo.entity.RegionIndex;
+import me.rentsignal.locationInfo.repository.RegionIndexRepository;
+import me.rentsignal.recommendation.dto.AiRecommendRequestDto;
+import me.rentsignal.user.entity.Role;
+import me.rentsignal.user.service.AuthService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+/**
+ * 지수 데이터 (소비자 심리지수, 전월세 통합지수, 지하철 역세권 지수) 저장
+ */
+public class IndexService {
+
+    private final ObjectMapper objectMapper;
+    @Value("${VILLA_RENT_INDEX_API_URL}")
+    private String VILLA_RENT_INDEX_API_URL;
+
+    @Value("${APT_RENT_INDEX_API_URL}")
+    private String APT_RENT_INDEX_API_URL;
+
+    private final RegionIndexRepository regionIndexRepository;
+    private final RegionRepository regionRepository;
+    private final AuthService authService;
+
+    public void saveAptRentCompositeIndex(Long userId) {
+        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
+
+        // 서울 > 강북지역 > 도심권
+        Region northCentral = findRegionByAreaGroupAndAreaName("강북", "도심권");
+        saveRegionIndex(northCentral, HousingType.APARTMENT,
+                getFilteredRentIndex("520010", HousingType.APARTMENT));
+
+
+        // 서울 > 강북지역 > 동북권
+        Region northNorthEast = findRegionByAreaGroupAndAreaName("강북", "동북권");
+        saveRegionIndex(northNorthEast, HousingType.APARTMENT,
+                getFilteredRentIndex("520011", HousingType.APARTMENT));
+
+        // 서울 > 강북지역 > 서북권
+        Region northNorthWest = findRegionByAreaGroupAndAreaName("강북", "서북권");
+        saveRegionIndex(northNorthWest, HousingType.APARTMENT,
+                getFilteredRentIndex("520012", HousingType.APARTMENT));
+
+        // 서울 > 강남지역 > 서남권
+        Region southSouthWest = findRegionByAreaGroupAndAreaName("강남", "서남권");
+        saveRegionIndex(southSouthWest, HousingType.APARTMENT,
+                getFilteredRentIndex("520014", HousingType.APARTMENT));
+
+        // 서울 > 강남지역 > 동남권
+        Region southSouthEast = findRegionByAreaGroupAndAreaName("강남", "동남권");
+        saveRegionIndex(southSouthEast, HousingType.APARTMENT,
+                getFilteredRentIndex("520015", HousingType.APARTMENT));
+
+    }
+
+    // 권역 조회
+    private Region findRegionByAreaGroupAndAreaName(String areaGroup, String areaName) {
+        return regionRepository.findByAreaGroupAndAreaName(areaGroup, areaName)
+                .orElseThrow(() -> new BaseException(ErrorCode.REGION_NOT_FOUND, "해당 권역을 찾을 수 없습니다. - " + areaGroup + " " + areaName));
+    }
+
+    // 1년 전까지의 전월세 통합지수 조회
+    private List<IndexApiResponseDto.Row> getFilteredRentIndex(String classificationId, HousingType housingType) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<AiRecommendRequestDto> requestEntity = new HttpEntity<>(headers);
+
+        IndexApiResponseDto indexApiResponseDto;
+
+        String API_URL;
+        if (housingType == HousingType.APARTMENT) {
+            API_URL = APT_RENT_INDEX_API_URL + classificationId;
+        } else if (housingType == HousingType.MULTI_FAMILY_HOUSE) {
+            API_URL = VILLA_RENT_INDEX_API_URL + classificationId;
+        } else {
+            throw new BaseException(ErrorCode.INVALID_HOUSING_TYPE, "잘못된 housing type입니다. - " + housingType.name());
+        }
+
+        try {
+
+            String responseBody = restTemplate
+                    .exchange(API_URL, HttpMethod.GET, requestEntity, String.class).getBody();
+
+            if (responseBody == null || responseBody.isBlank())
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+
+            indexApiResponseDto = objectMapper.readValue(responseBody, IndexApiResponseDto.class);
+
+        } catch (ResourceAccessException e) {
+            log.error("외부 API 연결 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("외부 API 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+        }
+
+        List<IndexApiResponseDto.Row> rows = indexApiResponseDto.getSttsApiTblData().stream()
+                .filter(data -> data.getRow() != null)
+                .findFirst()
+                .orElseThrow(() -> new BaseException(ErrorCode.EXTERNAL_API_ERROR, "지수 데이터 row가 없습니다."))
+                .getRow();
+
+        return rows.stream()
+                .filter(row -> row.getDate() != null)
+                .filter(row -> {
+                    String date = row.getDate();
+                    return date.compareTo("202502") >=0 && date.compareTo("202602") <=0;
+                }).toList();
+    }
+
+    private void saveRegionIndex(Region region, HousingType housingType,
+                                 List<IndexApiResponseDto.Row> rows) {
+        for (IndexApiResponseDto.Row row : rows) {
+            try {
+                regionIndexRepository.save(RegionIndex.builder()
+                        .region(region)
+                        .housingType(housingType)
+                        .rentCompositeIndex(row.getValue().setScale(1, RoundingMode.HALF_UP))
+                        .baseYearMonth(row.getDate()).build());
+            } catch (DataIntegrityViolationException e) {
+                throw new BaseException(ErrorCode.DUPLICATED_DATA, "해당 권역에 해당 기간의 "+ housingType + " 전월세 통합지수가 이미 존재합니다. - " + region.getAreaGroup() + " " + region.getAreaName());
+            }
+        }
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/service/IndexService.java
+++ b/src/main/java/me/rentsignal/data/service/IndexService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 
@@ -44,34 +43,34 @@ public class IndexService {
     private final RegionRepository regionRepository;
     private final AuthService authService;
 
-    public void saveAptRentCompositeIndex(Long userId) {
+    public void saveRentCompositeIndex(Long userId, HousingType housingType) {
         authService.validateUserAccess(userId, Role.ROLE_ADMIN);
 
         // 서울 > 강북지역 > 도심권
         Region northCentral = findRegionByAreaGroupAndAreaName("강북", "도심권");
-        saveRegionIndex(northCentral, HousingType.APARTMENT,
-                getFilteredRentIndex("520010", HousingType.APARTMENT));
+        saveRegionIndex(northCentral, housingType,
+                getFilteredRentIndex("520010", housingType));
 
 
         // 서울 > 강북지역 > 동북권
         Region northNorthEast = findRegionByAreaGroupAndAreaName("강북", "동북권");
-        saveRegionIndex(northNorthEast, HousingType.APARTMENT,
-                getFilteredRentIndex("520011", HousingType.APARTMENT));
+        saveRegionIndex(northNorthEast, housingType,
+                getFilteredRentIndex("520011", housingType));
 
         // 서울 > 강북지역 > 서북권
         Region northNorthWest = findRegionByAreaGroupAndAreaName("강북", "서북권");
-        saveRegionIndex(northNorthWest, HousingType.APARTMENT,
-                getFilteredRentIndex("520012", HousingType.APARTMENT));
+        saveRegionIndex(northNorthWest, housingType,
+                getFilteredRentIndex("520012", housingType));
 
         // 서울 > 강남지역 > 서남권
         Region southSouthWest = findRegionByAreaGroupAndAreaName("강남", "서남권");
-        saveRegionIndex(southSouthWest, HousingType.APARTMENT,
-                getFilteredRentIndex("520014", HousingType.APARTMENT));
+        saveRegionIndex(southSouthWest, housingType,
+                getFilteredRentIndex("520014", housingType));
 
         // 서울 > 강남지역 > 동남권
         Region southSouthEast = findRegionByAreaGroupAndAreaName("강남", "동남권");
-        saveRegionIndex(southSouthEast, HousingType.APARTMENT,
-                getFilteredRentIndex("520015", HousingType.APARTMENT));
+        saveRegionIndex(southSouthEast, housingType,
+                getFilteredRentIndex("520015", housingType));
 
     }
 

--- a/src/main/java/me/rentsignal/data/service/LegalDongImportService.java
+++ b/src/main/java/me/rentsignal/data/service/LegalDongImportService.java
@@ -1,7 +1,5 @@
 package me.rentsignal.data.service;
 
-import lombok.Builder;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.data.LegalDongCsvReader;
 import me.rentsignal.data.dto.LegalDongCsvRowDto;
@@ -43,12 +41,10 @@ public class LegalDongImportService {
         // 1. 편의를 위해 csv 한 행 -> LegalDongCsvRowDto로 변환
         List<LegalDongCsvRowDto> rows = legalDongCsvReader.read();
 
-        // 2. DB 조회 최소화를 위해 행정구역 레벨별로 map 생성
+        // 2. DB 조회 최소화를 위해 행정구역 레벨별 데이터를 code 기준으로 map 생성
         Map<String, Province> provinceMap = loadProvinceMap();
         Map<String, District> districtMap = loadDistrictMap();
-        NeighborhoodMaps neighborhoodMaps = loadNeighborhoodMaps();
-        Map<String, Neighborhood> neighborhoodCodeMap = neighborhoodMaps.getNeighborhoodCodeMap();
-        Map<String, Neighborhood> neighborhoodKeyMap = neighborhoodMaps.getNeighborhoodKeyMap();
+        Map<String, Neighborhood> neighborhoodMap = loadNeighborhoodMap();
         Map<String, Ri> riMap = loadRiMap();
 
         // 3. csv 한 줄씩 처리 -> 저장되어있지 않던 데이터는 저장
@@ -64,32 +60,31 @@ public class LegalDongImportService {
                 saveDistrict(row, provinceMap, districtMap);
             }
             else if (isNeighborhoodRow(row)) { // 읍/면/동 레벨
-                saveNeighborhood(row, provinceMap, districtMap, neighborhoodCodeMap, neighborhoodKeyMap);
+                saveNeighborhood(row, provinceMap, districtMap, neighborhoodMap);
             }
             else if (isRiRow(row)) { // 리 레벨
-                saveRi(row, provinceMap, districtMap, neighborhoodKeyMap, riMap);
+                saveRi(row, provinceMap, districtMap, neighborhoodMap, riMap);
             }
         }
     }
 
     // ---------- 행정구역 레벨별로 저장 ----------
 
-    private Province saveProvince(LegalDongCsvRowDto row, Map<String, Province> map) {
-        // 이미 해당 code의 Province가 존재할 경우 재사용
+    private void saveProvince(LegalDongCsvRowDto row, Map<String, Province> map) {
+        // 이미 해당 code의 Province가 존재할 경우 저장 필요 X
         Province province = map.get(row.getCode());
-        if (province != null) return province;
+        if (province != null) return;
 
         Province newProvince = provinceRepository.save(Province.builder()
                 .name(row.getProvinceName())
                 .code(row.getCode()).build());
 
         map.put(newProvince.getCode(), newProvince);
-        return newProvince;
     }
 
-    private District saveDistrict(LegalDongCsvRowDto row, Map<String, Province> provinceMap, Map<String, District> districtMap) {
+    private void saveDistrict(LegalDongCsvRowDto row, Map<String, Province> provinceMap, Map<String, District> districtMap) {
         District district = districtMap.get(row.getCode());
-        if (district != null) return district;
+        if (district != null) return;
 
         Province province = findProvinceByName(provinceMap, row.getProvinceName());
 
@@ -99,54 +94,37 @@ public class LegalDongImportService {
                 .province(province).build());
 
         districtMap.put(newDistrict.getCode(), newDistrict);
-        return newDistrict;
     }
 
-    private Neighborhood saveNeighborhood(LegalDongCsvRowDto row,
+    private void saveNeighborhood(LegalDongCsvRowDto row,
                                           Map<String, Province> provinceMap,
                                           Map<String, District> districtMap,
-                                          Map<String, Neighborhood> neighborhoodCodeMap,
-                                          Map<String, Neighborhood> neighborhoodKeyMap) {
-        Neighborhood neighborhoodByCode = neighborhoodCodeMap.get(row.getCode());
-        if (neighborhoodByCode != null) return neighborhoodByCode;
+                                          Map<String, Neighborhood> neighborhoodMap) {
+        Neighborhood neighborhood = neighborhoodMap.get(row.getCode());
+        if (neighborhood != null) return;
 
         Province province = findProvinceByName(provinceMap, row.getProvinceName());
         District district = findDistrictByNameAndProvince(districtMap, province, row.getDistrictName());
-
-        // 중복 (code는 다르고 같은 district 내 name이 동일한 경우)  방지를 위해 key 기준으로 한 번 더 체크
-        String key = neighborhoodKey(district, row.getNeighborhoodName());
-        Neighborhood neighborhoodByKey = neighborhoodKeyMap.get(key);
-        if (neighborhoodByKey != null) { // 중복일 경우
-            neighborhoodCodeMap.put(row.getCode(), neighborhoodByKey);
-            return neighborhoodByKey;
-        }
 
         Neighborhood newNeighborhood = neighborhoodRepository.save(Neighborhood.builder()
                 .name(row.getNeighborhoodName())
                 .code(row.getCode())
                 .district(district).build());
 
-        neighborhoodCodeMap.put(newNeighborhood.getCode(), newNeighborhood);
-        neighborhoodKeyMap.put(key, newNeighborhood);
-        return newNeighborhood;
+        neighborhoodMap.put(newNeighborhood.getCode(), newNeighborhood);
     }
 
-    private Ri saveRi(LegalDongCsvRowDto row,
+    private void saveRi(LegalDongCsvRowDto row,
                       Map<String, Province> provinceMap,
                       Map<String, District> districtMap,
-                      Map<String, Neighborhood> neighborhoodKeyMap,
+                      Map<String, Neighborhood> neighborhoodMap,
                       Map<String, Ri> riMap) {
         Ri ri = riMap.get(row.getCode());
-        if (ri != null) return ri;
+        if (ri != null) return;
 
         Province province = findProvinceByName(provinceMap, row.getProvinceName());
         District district = findDistrictByNameAndProvince(districtMap, province, row.getDistrictName());
-
-        String key = neighborhoodKey(district, row.getNeighborhoodName());
-        Neighborhood neighborhood = neighborhoodKeyMap.get(key);
-        if (neighborhood == null) {
-            throw new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 읍/면/동을 찾을 수 없습니다. - " + district.getName() + " " + row.getNeighborhoodName());
-        }
+        Neighborhood neighborhood = findNeighborhoodByNameAndDistrict(neighborhoodMap, district, row.getNeighborhoodName());
 
         Ri newRi = riRepository.save(Ri.builder()
                 .name(row.getRiName())
@@ -154,7 +132,6 @@ public class LegalDongImportService {
                 .neighborhood(neighborhood).build());
 
         riMap.put(newRi.getCode(), newRi);
-        return newRi;
     }
 
 
@@ -172,6 +149,14 @@ public class LegalDongImportService {
                 .filter(d -> d.getName().equals(name))
                 .findFirst()
                 .orElseThrow(() -> new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 시/군/구를 찾을 수 없습니다. - " + province.getName() + " " + name));
+    }
+
+    private Neighborhood findNeighborhoodByNameAndDistrict(Map<String, Neighborhood> neighborhoodMap, District district, String name) {
+        return neighborhoodMap.values().stream()
+                .filter(n -> n.getDistrict().getId().equals(district.getId()))
+                .filter(n -> n.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 읍/면/동을 찾을 수 없습니다. - " + district.getName() + " " + name));
     }
 
 
@@ -219,20 +204,9 @@ public class LegalDongImportService {
                 .collect(Collectors.toMap(District::getCode, d -> d));
     }
 
-    private NeighborhoodMaps loadNeighborhoodMaps() {
-        List<Neighborhood> all = neighborhoodRepository.findAll();
-
-        Map<String, Neighborhood> neighborhoodCodeMap = all.stream()
+    private Map<String, Neighborhood> loadNeighborhoodMap() {
+        return neighborhoodRepository.findAll().stream()
                 .collect(Collectors.toMap(Neighborhood::getCode, n -> n));
-
-        Map<String, Neighborhood> neighborhoodKeyMap = all.stream()
-                .collect(Collectors.toMap(
-                        n -> n.getDistrict().getId() + "|" + n.getName(),
-                        n -> n));
-
-        return NeighborhoodMaps.builder()
-                .neighborhoodCodeMap(neighborhoodCodeMap)
-                .neighborhoodKeyMap(neighborhoodKeyMap).build();
     }
 
     private Map<String, Ri> loadRiMap() {
@@ -240,23 +214,8 @@ public class LegalDongImportService {
                 .collect(Collectors.toMap(Ri::getCode, ri -> ri));
     }
 
-
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
-    }
-
-    private String neighborhoodKey(District district, String name) {
-        return district.getId() + "|" + name;
-    }
-
-    @Data
-    @Builder
-    public static class NeighborhoodMaps {
-
-        private Map<String, Neighborhood> neighborhoodCodeMap;
-
-        private Map<String, Neighborhood> neighborhoodKeyMap;
-
     }
 
 }

--- a/src/main/java/me/rentsignal/data/service/RegionDataService.java
+++ b/src/main/java/me/rentsignal/data/service/RegionDataService.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class DataService {
+public class RegionDataService {
 
     private final AuthService authService;
     private final DistrictRepository districtRepository;

--- a/src/main/java/me/rentsignal/data/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/RentIndexService.java
@@ -11,13 +11,13 @@ import me.rentsignal.location.repository.RegionRepository;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import me.rentsignal.locationInfo.repository.RegionIndexRepository;
-import me.rentsignal.recommendation.dto.AiRecommendRequestDto;
 import me.rentsignal.user.entity.Role;
 import me.rentsignal.user.service.AuthService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
@@ -43,6 +43,7 @@ public class RentIndexService {
     private final RegionRepository regionRepository;
     private final AuthService authService;
 
+    @Transactional
     public void saveRentCompositeIndex(Long userId, HousingType housingType) {
         authService.validateUserAccess(userId, Role.ROLE_ADMIN);
 
@@ -84,9 +85,6 @@ public class RentIndexService {
     private List<IndexApiResponseDto.Row> getFilteredRentIndex(String classificationId, HousingType housingType) {
         RestTemplate restTemplate = new RestTemplate();
 
-        HttpHeaders headers = new HttpHeaders();
-        HttpEntity<AiRecommendRequestDto> requestEntity = new HttpEntity<>(headers);
-
         IndexApiResponseDto indexApiResponseDto;
 
         String API_URL;
@@ -99,15 +97,13 @@ public class RentIndexService {
         }
 
         try {
-
             String responseBody = restTemplate
-                    .exchange(API_URL, HttpMethod.GET, requestEntity, String.class).getBody();
+                    .exchange(API_URL, HttpMethod.GET, null, String.class).getBody();
 
             if (responseBody == null || responseBody.isBlank())
                 throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
 
             indexApiResponseDto = objectMapper.readValue(responseBody, IndexApiResponseDto.class);
-
         } catch (ResourceAccessException e) {
             log.error("외부 API 연결 에러 - " + e.getMessage());
             throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
@@ -128,7 +124,7 @@ public class RentIndexService {
                 .filter(row -> row.getDate() != null)
                 .filter(row -> {
                     String date = row.getDate();
-                    return date.compareTo("202502") >=0 && date.compareTo("202602") <=0;
+                    return date.compareTo("202502") >=0 && date.compareTo("202606") <=0;
                 }).toList();
     }
 

--- a/src/main/java/me/rentsignal/data/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/RentIndexService.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * 지수 데이터 (소비자 심리지수, 전월세 통합지수, 지하철 역세권 지수) 저장
  */
-public class IndexService {
+public class RentIndexService {
 
     private final ObjectMapper objectMapper;
     @Value("${VILLA_RENT_INDEX_API_URL}")

--- a/src/main/java/me/rentsignal/data/service/SentimentIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/SentimentIndexService.java
@@ -1,0 +1,91 @@
+package me.rentsignal.data.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.rentsignal.data.dto.SentimentIndexApiResponseDto;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.Province;
+import me.rentsignal.location.repository.ProvinceRepository;
+import me.rentsignal.locationInfo.entity.ProvinceIndex;
+import me.rentsignal.locationInfo.repository.ProvinceIndexRepository;
+import me.rentsignal.user.entity.Role;
+import me.rentsignal.user.service.AuthService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SentimentIndexService {
+
+    private final AuthService authService;
+    private final ProvinceRepository provinceRepository;
+    private final ProvinceIndexRepository provinceIndexRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${CONSUMER_SENTIMENT_INDEX_API_URL}")
+    private String CONSUMER_SENTIMENT_INDEX_API_URL;
+
+    @Transactional
+    public void saveConsumerSentimentIndex(Long userId) {
+        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        List<SentimentIndexApiResponseDto> indexList;
+
+        try {
+            String responseBody = restTemplate
+                    .exchange(CONSUMER_SENTIMENT_INDEX_API_URL, HttpMethod.GET, null, String.class).getBody();
+
+            if (responseBody == null || responseBody.isBlank())
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+
+            indexList = objectMapper.readValue(responseBody, new com.fasterxml.jackson.core.type.TypeReference<List<SentimentIndexApiResponseDto>>() {});
+        } catch (ResourceAccessException e) {
+            log.error("외부 API 연결 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("외부 API 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+        }
+
+        // Province 미리 불러오기
+        Map<String, Province> provinceMap = provinceRepository.findAll().stream()
+                .collect(Collectors.toMap(Province::getName, p -> p));
+
+        if (indexList == null)
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "소비자 심리지수 데이터가 없습니다.");
+
+        for (SentimentIndexApiResponseDto index : indexList) {
+            Province province = provinceMap.get(index.getProvinceName());
+
+            // 수도권, 전국 등 시/도가 아닌 값은 패스
+            if (province == null) continue;
+
+            try {
+                provinceIndexRepository.save(
+                        ProvinceIndex.builder()
+                                .province(province)
+                                .consumerSentimentIndex(index.getValue())
+                                .baseYearMonth(index.getDate()).build()
+                );
+            } catch (DataIntegrityViolationException e) {
+                throw new BaseException(ErrorCode.DUPLICATED_DATA, "해당 시/도에 해당 기간의 소비자 심리지수가 이미 존재합니다. - " + province.getName());
+            }
+        }
+    }
+}

--- a/src/main/java/me/rentsignal/data/service/SubwayIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/SubwayIndexService.java
@@ -1,0 +1,156 @@
+package me.rentsignal.data.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.rentsignal.data.dto.IndexApiResponseDto;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.District;
+import me.rentsignal.location.repository.DistrictRepository;
+import me.rentsignal.locationInfo.entity.DistrictIndex;
+import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
+import me.rentsignal.user.entity.Role;
+import me.rentsignal.user.service.AuthService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubwayIndexService {
+
+    @Value("${SUBWAY_ACCESSIBILITY_INDEX_API_URL}")
+    private String SUBWAY_ACCESSIBILITY_INDEX_API_URL;
+
+    private static final List<String> CITIES = List.of("성남", "수원", "안양", "고양", "용인", "부천", "안산", "천안", "화성");
+
+    private final ObjectMapper objectMapper;
+    private final DistrictIndexRepository districtIndexRepository;
+    private final DistrictRepository districtRepository;
+    private final AuthService authService;
+
+    @Transactional
+    public void saveSubwayAccessibilityIndex(Long userId) {
+        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
+
+        // 1. 외부 API에서 지하철 역세권 지수 데이터 조회
+        List<IndexApiResponseDto.Row> rows = getSubwayIndexRows();
+
+        // 2. DB에서 District를 { 'Province 이름 > District 이름', District } 형식의 key로 조회할 수 있도록 Map 생성
+        Map<String, District> provinceAndDistrictMap = districtRepository.findAll().stream()
+                .collect(Collectors.toMap(
+                        d -> d.getProvince().getName() + ">" + d.getName(), d -> d
+                ));
+
+
+        for (IndexApiResponseDto.Row row : rows) {
+            // 3-1. 외부 API 데이터의 지역명을 DB 형식에 맞게 변환 (key 생성)
+            String fullName = row.getFullName();
+            if (fullName == null || fullName.isBlank()) {
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "데이터의 CLS_FULLNM이 비어있습니다.");
+            }
+
+            String[] parts = fullName.split(">");
+            if (parts.length != 2) {
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "잘못된 CLS_FULLNM 형식입니다. - " + fullName);
+            }
+
+            String provinceName = convertProvinceName(parts[0].trim());
+            String districtName = convertDistrictName(parts[1].trim());
+
+            String key = provinceName + ">" + districtName;
+
+            // 3-2. key에 해당하는 province + district 조합 있는지 확인
+            District district = provinceAndDistrictMap.get(key);
+            if (district == null) {
+                throw new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 시/군/구를 찾을 수 없습니다. - " + key);
+            }
+
+            // DTA_VAL 값이 null인 데이터는 저장 X
+            BigDecimal value = row.getValue();
+            if (value == null) continue;
+
+            try {
+                districtIndexRepository.save(DistrictIndex.builder()
+                        .district(district)
+                        .subwayAccessibilityIndex(value.setScale(1, RoundingMode.HALF_UP))
+                        .baseYearMonth(row.getDate()).build());
+            } catch (DataIntegrityViolationException e) {
+                throw new BaseException(ErrorCode.DUPLICATED_DATA, "해당 시/군/구에 해당 기간의 지하철 역세권 지수가 이미 존재합니다. - " + district.getName());
+            }
+        }
+    }
+
+    // 외부 API 호출해 데이터 조회 후 Row에 매핑
+    private List<IndexApiResponseDto.Row> getSubwayIndexRows() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        IndexApiResponseDto indexApiResponseDto;
+
+        try {
+            String responseBody = restTemplate
+                    .exchange(SUBWAY_ACCESSIBILITY_INDEX_API_URL, HttpMethod.GET, null, String.class).getBody();
+
+            if (responseBody == null || responseBody.isBlank())
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+
+            indexApiResponseDto = objectMapper.readValue(responseBody, IndexApiResponseDto.class);
+        } catch (ResourceAccessException e) {
+            log.error("외부 API 연결 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("외부 API 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+        }
+
+        return indexApiResponseDto.getSttsApiTblData().stream()
+                .filter(data -> data.getRow() != null)
+                .findFirst()
+                .orElseThrow(() -> new BaseException(ErrorCode.EXTERNAL_API_ERROR, "지수 데이터 row가 없습니다."))
+                .getRow();
+    }
+
+    // 시/도 이름 약어 -> 정식 시/도 이름으로 변환
+    private String convertProvinceName(String rawName) {
+        return switch (rawName) {
+            case "서울" -> "서울특별시";
+            case "대전" -> "대전광역시";
+            case "울산" -> "울산광역시";
+            case "광주" -> "광주광역시";
+            case "인천" -> "인천광역시";
+            case "대구" -> "대구광역시";
+            case "부산" -> "부산광역시";
+            case "경북" -> "경상북도";
+            case "경남" -> "경상남도";
+            case "강원" -> "강원특별자치도";
+            case "경기" -> "경기도";
+            case "충남" -> "충청남도";
+            default -> rawName;
+        };
+    }
+
+    // 시/군/구 이름 중 XXOO구를 XX시OO구로 변환 (데이터 형식 통일)
+    private String convertDistrictName(String rawName) {
+        for (String city : CITIES) {
+            if (rawName.startsWith(city) && rawName.endsWith("구"))
+                return city + "시" + rawName.substring(city.length());
+        }
+
+        return rawName;
+    }
+
+}

--- a/src/main/java/me/rentsignal/global/exception/ErrorCode.java
+++ b/src/main/java/me/rentsignal/global/exception/ErrorCode.java
@@ -24,12 +24,15 @@ public enum ErrorCode {
 
     // 데이터 관련
     CSV_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CSV 읽기에 실패했습니다."),
+    INVALID_HOUSING_TYPE(HttpStatus.NOT_FOUND, "잘못된 housing type입니다."),
+    DUPLICATED_DATA(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
 
     // 지역 관련
     PROVINCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시/도를 찾을 수 없습니다."),
     DISTRICT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시/군/구를 찾을 수 없습니다."),
     NEIGHBORHOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 읍/면/동을 찾을 수 없습니다."),
     RI_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리를 찾을 수 없습니다."),
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 권역을 찾을 수 없습니다."),
 
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/me/rentsignal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/rentsignal/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -47,6 +48,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
                 .body(BaseResponse.error(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    // RequestParam 타입 변환 실패한 경우
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseResponse<?>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException - " + e.getMessage());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(BaseResponse.error(ErrorCode.INVALID_INPUT_VALUE, "Request Param 타입 변환에 실패했습니다."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/me/rentsignal/location/entity/District.java
+++ b/src/main/java/me/rentsignal/location/entity/District.java
@@ -35,11 +35,19 @@ public class District extends BaseTimeEntity {
     @OneToMany(mappedBy = "district")
     private List<Neighborhood> neighborhoods = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
     @Builder
     public District(String name, String code, Province province) {
         this.name = name;
         this.code = code;
         this.province = province;
+    }
+
+    public void assignRegion(Region region) {
+        this.region = region;
     }
 
 }

--- a/src/main/java/me/rentsignal/location/entity/Region.java
+++ b/src/main/java/me/rentsignal/location/entity/Region.java
@@ -2,9 +2,13 @@ package me.rentsignal.location.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.rentsignal.global.entity.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 권역 (ex. 강남 서남권, 강북 도심권)
@@ -12,11 +16,6 @@ import me.rentsignal.global.entity.BaseTimeEntity;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        columnNames = {"province_id", "area_group", "area_name"})}
-)
 public class Region extends BaseTimeEntity {
 
     @Id
@@ -31,8 +30,22 @@ public class Region extends BaseTimeEntity {
     @Column(nullable = false, name = "area_name")
     private String areaName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "province_id", nullable = false)
-    private Province province;
+    @OneToMany(mappedBy = "region")
+    private List<District> districts = new ArrayList<>();
+
+    @Builder
+    public Region(String areaGroup, String areaName) {
+        this.areaGroup = areaGroup;
+        this.areaName = areaName;
+    }
+
+    public void addDistricts(List<District> districts) {
+        for (District district : districts) {
+            if (!this.districts.contains(district)) {
+                this.districts.add(district);
+            }
+            district.assignRegion(this);
+        }
+    }
 
 }

--- a/src/main/java/me/rentsignal/location/repository/DistrictRepository.java
+++ b/src/main/java/me/rentsignal/location/repository/DistrictRepository.java
@@ -1,9 +1,13 @@
 package me.rentsignal.location.repository;
 
 import me.rentsignal.location.entity.District;
+import me.rentsignal.location.entity.Province;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DistrictRepository extends JpaRepository<District, Long> {
+    Optional<District> findByNameAndProvince(String name, Province province);
 }

--- a/src/main/java/me/rentsignal/location/repository/ProvinceRepository.java
+++ b/src/main/java/me/rentsignal/location/repository/ProvinceRepository.java
@@ -4,6 +4,9 @@ import me.rentsignal.location.entity.Province;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ProvinceRepository extends JpaRepository<Province, Long> {
+    Optional<Province> findByName(String name);
 }

--- a/src/main/java/me/rentsignal/location/repository/RegionRepository.java
+++ b/src/main/java/me/rentsignal/location/repository/RegionRepository.java
@@ -4,6 +4,9 @@ import me.rentsignal.location.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RegionRepository extends JpaRepository<Region, Long> {
+    Optional<Region> findByAreaGroupAndAreaName(String areaGroup, String areaName);
 }

--- a/src/main/java/me/rentsignal/locationInfo/entity/DistrictIndex.java
+++ b/src/main/java/me/rentsignal/locationInfo/entity/DistrictIndex.java
@@ -3,6 +3,7 @@ package me.rentsignal.locationInfo.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.rentsignal.global.entity.BaseTimeEntity;
@@ -38,5 +39,12 @@ public class DistrictIndex extends BaseTimeEntity {
     @Pattern(regexp = "\\d{6}")
     @Column(nullable = false, name = "base_year_month", length = 6)
     private String baseYearMonth;
+
+    @Builder
+    public DistrictIndex(District district, BigDecimal subwayAccessibilityIndex, String baseYearMonth) {
+        this.district = district;
+        this.subwayAccessibilityIndex = subwayAccessibilityIndex;
+        this.baseYearMonth = baseYearMonth;
+    }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/entity/ProvinceIndex.java
+++ b/src/main/java/me/rentsignal/locationInfo/entity/ProvinceIndex.java
@@ -3,6 +3,7 @@ package me.rentsignal.locationInfo.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.rentsignal.global.entity.BaseTimeEntity;
@@ -38,5 +39,12 @@ public class ProvinceIndex extends BaseTimeEntity {
     @Pattern(regexp = "\\d{6}")
     @Column(nullable = false, name = "base_year_month", length = 6)
     private String baseYearMonth;
+
+    @Builder
+    public ProvinceIndex(Province province, BigDecimal consumerSentimentIndex, String baseYearMonth) {
+        this.province = province;
+        this.consumerSentimentIndex = consumerSentimentIndex;
+        this.baseYearMonth = baseYearMonth;
+    }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/entity/RegionIndex.java
+++ b/src/main/java/me/rentsignal/locationInfo/entity/RegionIndex.java
@@ -3,6 +3,7 @@ package me.rentsignal.locationInfo.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.rentsignal.global.entity.BaseTimeEntity;
@@ -35,12 +36,20 @@ public class RegionIndex extends BaseTimeEntity {
     @Column(name = "housing_type", nullable = false)
     private HousingType housingType;
 
-    @Column(nullable = false)
+    @Column(nullable = false, scale = 2)
     private BigDecimal rentCompositeIndex;
 
     // YYYYMM
     @Pattern(regexp = "\\d{6}")
     @Column(nullable = false, name = "base_year_month", length = 6)
     private String baseYearMonth;
+
+    @Builder
+    public RegionIndex(Region region, HousingType housingType, BigDecimal rentCompositeIndex, String baseYearMonth) {
+        this.region = region;
+        this.housingType = housingType;
+        this.rentCompositeIndex = rentCompositeIndex;
+        this.baseYearMonth = baseYearMonth;
+    }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.repository;
+
+import me.rentsignal.locationInfo.entity.DistrictIndex;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DistrictIndexRepository extends JpaRepository<DistrictIndex, Long> {
+}

--- a/src/main/java/me/rentsignal/locationInfo/repository/ProvinceIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/ProvinceIndexRepository.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.repository;
+
+import me.rentsignal.locationInfo.entity.ProvinceIndex;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProvinceIndexRepository extends JpaRepository<ProvinceIndex, Long> {
+}

--- a/src/main/java/me/rentsignal/locationInfo/repository/RegionIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/RegionIndexRepository.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.repository;
+
+import me.rentsignal.locationInfo.entity.RegionIndex;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RegionIndexRepository extends JpaRepository<RegionIndex, Long> {
+}


### PR DESCRIPTION
## ✅ 관련 이슈


## ✨ 작업 내용
- [x] 권역 저장 구현
- [x] 전월세 통합지수 저장 구현 (아파트, 연립 다세대)
- [x] 소비자 심리지수 저장 구현
- [x] 지하철 역세권 지수 저장 구현
- [x] 법정동 코드 및 행정구역 저장 부분 수정

## 📸 스크린샷


## 🗨️ 참고 사항
- 노션에 환경변수 업데이트해뒀습니다!
- ⭐ 법정동 코드 및 행정구역 데이터 저장 관련
지난 PR에서 이 부분을 구현했었는데, 이후 개발을 진행하면서 아래와 같은 문제점이 있어서 수정했습니다. 그래서 **기존 데이터 (Province, Distinct, Neighborhood, Ri)를 모두 지우시고** 새로 저장해주세요!
  - 화성시 데이터가 기존 csv 파일에서 누락되어 추가했습니다. 노션에 올려놓은 구글 드라이브에도 반영해놓았으니 **새로 다운받아주세요**!
  - 법정동 코드나 이름이 변경되었지만 (e.g. 대구직할시 -> 대구광역시) 이전 이름에 대한 데이터도 남아있는 경우 이 부분은 제외하고 저장하도록 코드 수정했습니다.
  - 참고 ) 저 같은 경우 아예 DB를 지우고 새로 생성했습니다. `DROP DATABASE rentsignal;
CREATE DATABASE rentsignal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`
