### PR TITLE
[Feat] 편의시설 - 편의점 데이터 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ sourceCompatibility = '17'
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://repo.osgeo.org/repository/release/")
+    }
 }
 
 dependencies {
@@ -29,6 +32,11 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // GeoTools
+    implementation 'org.geotools:gt-main:34.0'
+    implementation 'org.geotools:gt-referencing:34.0'
+    implementation 'org.geotools:gt-epsg-hsql:34.0'
 }
 
 test {

--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -3,10 +3,8 @@ package me.rentsignal.data.controller;
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.data.service.*;
 import me.rentsignal.global.response.BaseResponse;
-import me.rentsignal.global.security.CustomPrincipal;
 import me.rentsignal.locationInfo.entity.HousingType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,33 +19,32 @@ public class DataController {
     private final SubwayIndexService subwayIndexService;
 
     @PostMapping("/legal-dong")
-    public ResponseEntity<?> saveLegalDong(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        legalDongImportService.importLegalDongCsv(customPrincipal.getId());
+    public ResponseEntity<?> saveLegalDong() {
+        legalDongImportService.importLegalDongCsv();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/region")
-    public ResponseEntity<?> saveRegion(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        regionDataService.saveRegion(customPrincipal.getId());
+    public ResponseEntity<?> saveRegion() {
+        regionDataService.saveRegion();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/rent-index")
-    public ResponseEntity<?> saveRentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal,
-                                           @RequestParam HousingType housingType) {
-        rentIndexService.saveRentCompositeIndex(customPrincipal.getId(), housingType);
+    public ResponseEntity<?> saveRentIndex(@RequestParam HousingType housingType) {
+        rentIndexService.saveRentCompositeIndex(housingType);
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/consumer-sentiment-index")
-    public ResponseEntity<?> saveConsumerSentimentIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        sentimentIndexService.saveConsumerSentimentIndex(customPrincipal.getId());
+    public ResponseEntity<?> saveConsumerSentimentIndex() {
+        sentimentIndexService.saveConsumerSentimentIndex();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/subway-accessibility-index")
-    public ResponseEntity<?> saveSubwayAccessibilityIndex(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        subwayIndexService.saveSubwayAccessibilityIndex(customPrincipal.getId());
+    public ResponseEntity<?> saveSubwayAccessibilityIndex() {
+        subwayIndexService.saveSubwayAccessibilityIndex();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/controller/LifeStyleFactorDataCollector.java
+++ b/src/main/java/me/rentsignal/data/controller/LifeStyleFactorDataCollector.java
@@ -1,0 +1,24 @@
+package me.rentsignal.data.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.data.service.ConvenienceDataService;
+import me.rentsignal.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class LifeStyleFactorDataCollector {
+
+    private final ConvenienceDataService convenienceDataService;
+
+    @PostMapping("/convenience-store")
+    public ResponseEntity<?> saveConvenienceStore() {
+        convenienceDataService.saveConvenienceStore();
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/controller/LifeStyleFactorDataCollector.java
+++ b/src/main/java/me/rentsignal/data/controller/LifeStyleFactorDataCollector.java
@@ -1,7 +1,7 @@
 package me.rentsignal.data.controller;
 
 import lombok.RequiredArgsConstructor;
-import me.rentsignal.data.service.ConvenienceDataService;
+import me.rentsignal.data.service.ConvenienceStoreDataService;
 import me.rentsignal.global.response.BaseResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin")
 public class LifeStyleFactorDataCollector {
 
-    private final ConvenienceDataService convenienceDataService;
+    private final ConvenienceStoreDataService convenienceStoreDataService;
 
     @PostMapping("/convenience-store")
     public ResponseEntity<?> saveConvenienceStore() {
-        convenienceDataService.saveConvenienceStore();
+        convenienceStoreDataService.saveConvenienceStore();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/dto/ConvenienceStoreApiResponseDto.java
+++ b/src/main/java/me/rentsignal/data/dto/ConvenienceStoreApiResponseDto.java
@@ -1,0 +1,44 @@
+package me.rentsignal.data.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ConvenienceStoreApiResponseDto {
+
+    private Body body;
+
+    @Data
+    public static class Body {
+
+        private Items items;
+
+    }
+
+    @Data
+    public static class Items {
+
+        private List<Item> item;
+
+    }
+
+    @Data
+    public static class Item {
+
+        @JsonProperty("fclty_nm")
+        private String facilityName;
+
+        @JsonProperty("adres")
+        private String address;
+
+        @JsonProperty("x")
+        private Double x;
+
+        @JsonProperty("y")
+        private Double y;
+
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/service/ConvenienceDataService.java
+++ b/src/main/java/me/rentsignal/data/service/ConvenienceDataService.java
@@ -1,0 +1,276 @@
+package me.rentsignal.data.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.rentsignal.data.dto.ConvenienceStoreApiResponseDto;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.District;
+import me.rentsignal.location.entity.Neighborhood;
+import me.rentsignal.location.entity.Province;
+import me.rentsignal.location.repository.DistrictRepository;
+import me.rentsignal.location.repository.NeighborhoodRepository;
+import me.rentsignal.location.repository.ProvinceRepository;
+import me.rentsignal.locationInfo.entity.NeighborhoodConvenience;
+import me.rentsignal.locationInfo.repository.NeighborhoodConvenienceRepository;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.text.Normalizer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ConvenienceDataService {
+
+    private final ProvinceRepository provinceRepository;
+    private final DistrictRepository districtRepository;
+    private final NeighborhoodRepository neighborhoodRepository;
+    private final ObjectMapper objectMapper;
+
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+    private final NeighborhoodConvenienceRepository neighborhoodConvenienceRepository;
+    private static final MathTransform transform = createTransfrom();
+
+    @Value("${CONVENIENCE_STORE_API_URL}")
+    private String CONVENIENCE_STORE_API_URL;
+
+    /** 편의시설 - 편의점 저장 */
+    @Transactional
+    public void saveConvenienceStore() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        Map<String, Province> provinceMap = loadProvinceNameMap();
+        Map<String, District> districtMap = loadDistrictKeyMap();
+        Map<String, Neighborhood> neighborhoodMap = loadNeighborhoodKeyMap();
+
+        // 편의점 데이터 총 54342개, 한 페이지 최대 데이터 개수 1000개 -> 55번 반복
+        for (int i = 0; i < 55; i++) {
+            System.out.println((i+1) + "번째 페이지 조회 중 ..");
+
+            ConvenienceStoreApiResponseDto convenienceStoreApiResponseDto;
+            try {
+                String responseBody = restTemplate
+                        .exchange(CONVENIENCE_STORE_API_URL + (i+1), HttpMethod.GET, null, String.class).getBody();
+
+                if (responseBody == null || responseBody.isBlank())
+                    throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+
+                convenienceStoreApiResponseDto = objectMapper.readValue(responseBody, ConvenienceStoreApiResponseDto.class);
+            } catch (ResourceAccessException e) {
+                log.error("외부 API 연결 에러 - " + e.getMessage());
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+            } catch (BaseException e) {
+                throw e;
+            } catch (Exception e) {
+                log.error("외부 API 에러 - " + e.getMessage());
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+            }
+
+            List<ConvenienceStoreApiResponseDto.Item> stores = convenienceStoreApiResponseDto.getBody().getItems().getItem();
+
+            Set<String> convenienceStoreKeySet = neighborhoodConvenienceRepository.findAll().stream()
+                    .map(c -> convenienceStoreKey(c.getName(), c.getNeighborhood()))
+                    .collect(Collectors.toSet());
+
+            // 페이지 내 모든 편의점 저장
+            for (ConvenienceStoreApiResponseDto.Item item : stores) {
+                String address = item.getAddress();
+
+                if (address == null || address.isBlank()) {
+                    log.warn("address가 null이거나 비어있습니다. - " + item.getFacilityName());
+                    continue;
+                }
+
+                String[] arr = address.trim().split("\\s+");
+
+                if (arr.length < 3) {
+                    log.warn("주소 배열 길이가 3보다 작습니다. - " + address);
+                    continue;
+                }
+
+                // 주소에 해당하는 Neighborhood 찾기
+                Province province = findProvinceByName(provinceMap, arr[0]);
+                District district;
+                Neighborhood neighborhood;
+
+                String convertedName = convertDistrictName(arr[1], arr[2]);
+
+                if (convertedName == null) { // XX시 OO구 형태 X
+                    if (province.getName().equals("세종특별자치시") && arr[1].equals("세종특별자치시")){
+                        // 세종특별자치시 세종특별자치시 -> 세종특별자치시 세종시
+                        arr[1] = "세종시";
+                    }
+                    district = findDistrictByNameAndProvince(districtMap, province, arr[1]);
+                    neighborhood = findNeighborhoodByNameAndDistrict(neighborhoodMap, district, arr[2]);
+                } else {
+                    if (arr.length < 4) {
+                        log.warn("잘못된 주소 형식입니다. - " + address);
+                        continue;
+                    }
+                    district = findDistrictByNameAndProvince(districtMap, province, convertedName);
+                    neighborhood = findNeighborhoodByNameAndDistrict(neighborhoodMap, district, arr[3]);
+                }
+
+                // 동일 neighborhood의 동일 이름 가게인지 확인
+                String storeName = getNormalizedStoreName(item.getFacilityName());
+
+                String key = convenienceStoreKey(storeName, neighborhood);
+                if (convenienceStoreKeySet.contains(key)) {
+                    log.info("이미 저장된 편의점입니다. - " + item.getFacilityName());
+                    continue;
+                }
+
+                // Web Mercator 좌표 (x,y)를 WGS84 위도/경도로 변환
+                if (item.getX() == null || item.getY() == null || item.getX() == 0 || item.getY() == 0) {
+                    log.warn("x, y 값이 null이거나 0입니다. x - { }, y - {}", item.getX(), item.getY());
+                    continue;
+                }
+
+                List<Double> latLng = convertToLatLng(item.getX(), item.getY());
+
+                // 편의점 저장
+                neighborhoodConvenienceRepository.save(NeighborhoodConvenience.builder()
+                        .name(storeName)
+                        .type("편의점")
+                        .neighborhood(neighborhood)
+                        .latitude(latLng.get(0))
+                        .longitude(latLng.get(1)).build());
+
+                convenienceStoreKeySet.add(key);
+            }
+        }
+    }
+
+    /** 전각/반각을 같은 이름으로 판단해서 Duplicate Entry 오류 발생
+     * -> 정규화된 이름으로 변환 */
+    private String getNormalizedStoreName(String name) {
+        if (name == null || name.isBlank()) return null;
+
+        return Normalizer.normalize(name.trim(), Normalizer.Form.NFKC);
+    }
+
+    /** XX시 OO구를 XX시OO구라는 하나의 District 이름으로 변환 */
+    private String convertDistrictName(String name1, String name2) {
+        for (String city : SubwayIndexService.CITIES) {
+            if (name1.startsWith(city) && name2.endsWith("구"))
+                return name1 + name2;
+        }
+
+        return null;
+    }
+
+    /** 동일 neighborhood 내 동일 이름의 가게 중복 막기 위한 key */
+    private String convenienceStoreKey (String name, Neighborhood neighborhood) {
+        return name.trim() + "|" + neighborhood.getId();
+    }
+
+    /** EPSG:3857 (x,y) -> EPSG:4326 (위도, 경도) 변환 */
+    private List<Double> convertToLatLng(Double x, Double y) {
+        try {
+            Point sourcePoint = geometryFactory.createPoint(new Coordinate(x, y));
+            Point targetPoint = (Point) JTS.transform(sourcePoint, transform);
+
+            // EPSG:4326에서는 x = 경도, y = 위도
+            return List.of(targetPoint.getY(), targetPoint.getX());
+        } catch (Exception e) {
+            log.error("좌표 변환 실패 - " + e);
+            throw new BaseException(ErrorCode.CONVERT_FAILED, "위도/경도 변환에 실패했습니다.");
+        }
+    }
+
+    private static MathTransform createTransfrom() {
+        try {
+            CoordinateReferenceSystem sourceCrs = CRS.decode("EPSG:3857", true);
+            CoordinateReferenceSystem targetCrs = CRS.decode("EPSG:4326", true);
+            return CRS.findMathTransform(sourceCrs, targetCrs);
+        } catch (Exception e) {
+            log.error("좌표 변환 실패 - " + e);
+            throw new BaseException(ErrorCode.CONVERT_FAILED, "위도/경도 변환에 실패했습니다.");
+        }
+    }
+
+
+    // ---------- 행정구역 레벨별로 저장된 데이터 전체 조회 후 이름/복합키 기준 Map으로 변환 ----------
+
+    private Map<String, Province> loadProvinceNameMap() {
+        return provinceRepository.findAll().stream()
+                .collect(Collectors.toMap(Province::getName, p -> p));
+    }
+
+    private Map<String, District> loadDistrictKeyMap() {
+        return districtRepository.findAll().stream()
+                .collect(Collectors.toMap(
+                        d -> districtKey(d.getProvince().getName(), d.getName()),
+                        d -> d
+                ));
+    }
+
+    private Map<String, Neighborhood> loadNeighborhoodKeyMap() {
+        return neighborhoodRepository.findAll().stream()
+                .collect(Collectors.toMap(
+                        n -> neighborhoodKey(n.getDistrict().getProvince().getName(), n.getDistrict().getName(), n.getName()),
+                        n -> n
+                ));
+    }
+
+
+    // ---------- 행정구역 레벨별 map에서 이름으로 조회 ----------
+
+    private Province findProvinceByName(Map<String, Province> provinceMap, String name) {
+        Province province = provinceMap.get(name);
+
+        if (province == null)
+            throw new BaseException(ErrorCode.PROVINCE_NOT_FOUND, "해당 시/도를 찾을 수 없습니다. - " + name);
+
+        return province;
+    }
+
+    private District findDistrictByNameAndProvince(Map<String, District> districtMap, Province province, String name) {
+        String key = districtKey(province.getName(), name);
+        District district = districtMap.get(key);
+
+        if (district == null)
+            throw new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 시/군/구를 찾을 수 없습니다. - " + province.getName() + " " + name);
+
+        return district;
+    }
+
+    private Neighborhood findNeighborhoodByNameAndDistrict(Map<String, Neighborhood> neighborhoodMap, District district, String name) {
+        String key = neighborhoodKey(district.getProvince().getName(), district.getName(), name);
+        Neighborhood neighborhood = neighborhoodMap.get(key);
+
+        if (neighborhood == null)
+            throw new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 읍/면/동을 찾을 수 없습니다. - " + district.getName() + " " + name);
+
+        return neighborhood;
+    }
+
+
+    // ---------- 복합키 생성 ----------
+
+    private String districtKey(String provinceName, String districtName) {
+        return provinceName + "|" + districtName;
+    }
+
+    private String neighborhoodKey(String provinceName, String districtName, String neighborhoodName) {
+        return provinceName + "|" + districtName + "|" + neighborhoodName;
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/service/ConvenienceStoreDataService.java
+++ b/src/main/java/me/rentsignal/data/service/ConvenienceStoreDataService.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ConvenienceDataService {
+public class ConvenienceStoreDataService {
 
     private final ProvinceRepository provinceRepository;
     private final DistrictRepository districtRepository;

--- a/src/main/java/me/rentsignal/data/service/LegalDongImportService.java
+++ b/src/main/java/me/rentsignal/data/service/LegalDongImportService.java
@@ -13,8 +13,6 @@ import me.rentsignal.location.repository.DistrictRepository;
 import me.rentsignal.location.repository.NeighborhoodRepository;
 import me.rentsignal.location.repository.ProvinceRepository;
 import me.rentsignal.location.repository.RiRepository;
-import me.rentsignal.user.entity.Role;
-import me.rentsignal.user.service.AuthService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,12 +30,9 @@ public class LegalDongImportService {
     private final DistrictRepository districtRepository;
     private final NeighborhoodRepository neighborhoodRepository;
     private final RiRepository riRepository;
-    private final AuthService authService;
 
     /** csv 파일 읽어서 법정동 데이터 (코드, 시/도, 시/군/구, 읍/면/동, 리) 저장 */
-    public void importLegalDongCsv(Long userId) {
-        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
-
+    public void importLegalDongCsv() {
         // 1. 편의를 위해 csv 한 행 -> LegalDongCsvRowDto로 변환
         List<LegalDongCsvRowDto> rows = legalDongCsvReader.read();
 

--- a/src/main/java/me/rentsignal/data/service/RegionDataService.java
+++ b/src/main/java/me/rentsignal/data/service/RegionDataService.java
@@ -9,8 +9,6 @@ import me.rentsignal.location.entity.Region;
 import me.rentsignal.location.repository.DistrictRepository;
 import me.rentsignal.location.repository.ProvinceRepository;
 import me.rentsignal.location.repository.RegionRepository;
-import me.rentsignal.user.entity.Role;
-import me.rentsignal.user.service.AuthService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,15 +18,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RegionDataService {
 
-    private final AuthService authService;
     private final DistrictRepository districtRepository;
     private final RegionRepository regionRepository;
     private final ProvinceRepository provinceRepository;
 
     @Transactional
-    public void saveRegion(Long userId) {
-        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
-
+    public void saveRegion() {
         Province province = provinceRepository.findByName("서울특별시").orElseThrow(() ->
                 new BaseException(ErrorCode.PROVINCE_NOT_FOUND, "해당 시/도가 존재하지 않습니다. - 서울특별시"));
 

--- a/src/main/java/me/rentsignal/data/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/RentIndexService.java
@@ -11,8 +11,6 @@ import me.rentsignal.location.repository.RegionRepository;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import me.rentsignal.locationInfo.repository.RegionIndexRepository;
-import me.rentsignal.user.entity.Role;
-import me.rentsignal.user.service.AuthService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.*;
@@ -41,12 +39,9 @@ public class RentIndexService {
 
     private final RegionIndexRepository regionIndexRepository;
     private final RegionRepository regionRepository;
-    private final AuthService authService;
 
     @Transactional
-    public void saveRentCompositeIndex(Long userId, HousingType housingType) {
-        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
-
+    public void saveRentCompositeIndex(HousingType housingType) {
         // 서울 > 강북지역 > 도심권
         Region northCentral = findRegionByAreaGroupAndAreaName("강북", "도심권");
         saveRegionIndex(northCentral, housingType,

--- a/src/main/java/me/rentsignal/data/service/SentimentIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/SentimentIndexService.java
@@ -10,8 +10,6 @@ import me.rentsignal.location.entity.Province;
 import me.rentsignal.location.repository.ProvinceRepository;
 import me.rentsignal.locationInfo.entity.ProvinceIndex;
 import me.rentsignal.locationInfo.repository.ProvinceIndexRepository;
-import me.rentsignal.user.entity.Role;
-import me.rentsignal.user.service.AuthService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpMethod;
@@ -29,7 +27,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class SentimentIndexService {
 
-    private final AuthService authService;
     private final ProvinceRepository provinceRepository;
     private final ProvinceIndexRepository provinceIndexRepository;
     private final ObjectMapper objectMapper;
@@ -38,9 +35,7 @@ public class SentimentIndexService {
     private String CONSUMER_SENTIMENT_INDEX_API_URL;
 
     @Transactional
-    public void saveConsumerSentimentIndex(Long userId) {
-        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
-
+    public void saveConsumerSentimentIndex() {
         RestTemplate restTemplate = new RestTemplate();
 
         List<SentimentIndexApiResponseDto> indexList;

--- a/src/main/java/me/rentsignal/data/service/SubwayIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/SubwayIndexService.java
@@ -32,7 +32,7 @@ public class SubwayIndexService {
     @Value("${SUBWAY_ACCESSIBILITY_INDEX_API_URL}")
     private String SUBWAY_ACCESSIBILITY_INDEX_API_URL;
 
-    private static final List<String> CITIES = List.of("성남", "수원", "안양", "고양", "용인", "부천", "안산", "천안", "화성");
+    public static final List<String> CITIES = List.of("성남", "수원", "안양", "고양", "용인", "부천", "안산", "천안", "화성", "창원", "포항", "전주", "청주");
 
     private final ObjectMapper objectMapper;
     private final DistrictIndexRepository districtIndexRepository;

--- a/src/main/java/me/rentsignal/data/service/SubwayIndexService.java
+++ b/src/main/java/me/rentsignal/data/service/SubwayIndexService.java
@@ -10,8 +10,6 @@ import me.rentsignal.location.entity.District;
 import me.rentsignal.location.repository.DistrictRepository;
 import me.rentsignal.locationInfo.entity.DistrictIndex;
 import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
-import me.rentsignal.user.entity.Role;
-import me.rentsignal.user.service.AuthService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpMethod;
@@ -39,12 +37,9 @@ public class SubwayIndexService {
     private final ObjectMapper objectMapper;
     private final DistrictIndexRepository districtIndexRepository;
     private final DistrictRepository districtRepository;
-    private final AuthService authService;
 
     @Transactional
-    public void saveSubwayAccessibilityIndex(Long userId) {
-        authService.validateUserAccess(userId, Role.ROLE_ADMIN);
-
+    public void saveSubwayAccessibilityIndex() {
         // 1. 외부 API에서 지하철 역세권 지수 데이터 조회
         List<IndexApiResponseDto.Row> rows = getSubwayIndexRows();
 

--- a/src/main/java/me/rentsignal/global/exception/ErrorCode.java
+++ b/src/main/java/me/rentsignal/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     CSV_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CSV 읽기에 실패했습니다."),
     INVALID_HOUSING_TYPE(HttpStatus.NOT_FOUND, "잘못된 housing type입니다."),
     DUPLICATED_DATA(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
+    CONVERT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "위도/경도 변환에 실패했습니다."),
 
     // 지역 관련
     PROVINCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시/도를 찾을 수 없습니다."),

--- a/src/main/java/me/rentsignal/global/security/SecurityConfig.java
+++ b/src/main/java/me/rentsignal/global/security/SecurityConfig.java
@@ -1,7 +1,6 @@
 package me.rentsignal.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +43,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.GET, "/api/community/posts").permitAll()   // 게시글 목록은 전체 접근 허용
-                        .requestMatchers( "/api/community/**", "/api/mypage/**", "/api/recommend", "/api/admin/**").authenticated()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers( "/api/community/**", "/api/mypage/**", "/api/recommend").authenticated()
                         .anyRequest().permitAll())
 
                 .oauth2Login(oauth -> oauth

--- a/src/main/java/me/rentsignal/locationInfo/entity/NeighborhoodConvenience.java
+++ b/src/main/java/me/rentsignal/locationInfo/entity/NeighborhoodConvenience.java
@@ -2,6 +2,7 @@ package me.rentsignal.locationInfo.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.rentsignal.global.entity.BaseTimeEntity;
@@ -15,6 +16,11 @@ import java.math.BigDecimal;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"neighborhood_id", "name"}
+        )
+)
 public class NeighborhoodConvenience extends BaseTimeEntity {
 
     @Id
@@ -32,10 +38,19 @@ public class NeighborhoodConvenience extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, precision = 10, scale = 7)
-    private BigDecimal latitude;
+    @Column(nullable = false)
+    private Double latitude;
 
-    @Column(nullable = false, precision = 10, scale = 7)
-    private BigDecimal longitude;
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Builder
+    public NeighborhoodConvenience(Neighborhood neighborhood, String type, String name, Double latitude, Double longitude) {
+        this.neighborhood = neighborhood;
+        this.type = type;
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodConvenienceRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodConvenienceRepository.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.repository;
+
+import me.rentsignal.locationInfo.entity.NeighborhoodConvenience;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NeighborhoodConvenienceRepository extends JpaRepository<NeighborhoodConvenience, Long> {
+}


### PR DESCRIPTION
## ✅ 관련 이슈


## ✨ 작업 내용
- [x] 편의점 데이터 저장 구현
1. 오픈 API 특성상 한 번에 데이터 1000건만 조회 가능함 -> 요청 55번 반복하도록 구 (매 요청마다 콘솔창에 n번째 페이지 조회 중 .. 메시지가 뜨도록 했습니다)
2. 각 편의점 주소에 해당하는 Neighborhood 객체 조회
3. 동일 neighborhood 내 동일 이름의 가게가 없도록 중복 방지
중복데이터가 있을 경우 로그만 출력
전각/반각 차이로 인한 중복 방지를 위해 정규화한 이름을 저장하도록 구현
4. API에서 제공하는 (x, y)값을 위도, 경도로 변환
5. 편의점 객체 저장

## 📸 스크린샷


## 🗨️ 참고 사항
- 환경변수 (CONVENIENCE_STORE_API_URL) 업데이트 해놓았습니다!
- 데이터가 많아서 저장 시 약 1분에서 2분 정도 소요되니 참고해주세요!
- 데이터는 중복 제외하고 50321개입니다!