### PR TITLE
[Feat] 정보 탭 지수중심 데이터 조회 기능 구현

### DIFF
--- a/src/main/java/me/rentsignal/data/controller/DataController.java
+++ b/src/main/java/me/rentsignal/data/controller/DataController.java
@@ -14,9 +14,9 @@ public class DataController {
 
     private final LegalDongImportService legalDongImportService;
     private final RegionDataService regionDataService;
-    private final RentIndexService rentIndexService;
-    private final SentimentIndexService sentimentIndexService;
-    private final SubwayIndexService subwayIndexService;
+    private final RentIndexDataService rentIndexDataService;
+    private final SentimentIndexDataService sentimentIndexDataService;
+    private final SubwayIndexDataService subwayIndexDataService;
 
     @PostMapping("/legal-dong")
     public ResponseEntity<?> saveLegalDong() {
@@ -32,19 +32,19 @@ public class DataController {
 
     @PostMapping("/rent-index")
     public ResponseEntity<?> saveRentIndex(@RequestParam HousingType housingType) {
-        rentIndexService.saveRentCompositeIndex(housingType);
+        rentIndexDataService.saveRentCompositeIndex(housingType);
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/consumer-sentiment-index")
     public ResponseEntity<?> saveConsumerSentimentIndex() {
-        sentimentIndexService.saveConsumerSentimentIndex();
+        sentimentIndexDataService.saveConsumerSentimentIndex();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 
     @PostMapping("/subway-accessibility-index")
     public ResponseEntity<?> saveSubwayAccessibilityIndex() {
-        subwayIndexService.saveSubwayAccessibilityIndex();
+        subwayIndexDataService.saveSubwayAccessibilityIndex();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/service/ConvenienceStoreDataService.java
+++ b/src/main/java/me/rentsignal/data/service/ConvenienceStoreDataService.java
@@ -154,7 +154,7 @@ public class ConvenienceStoreDataService {
 
     /** XX시 OO구를 XX시OO구라는 하나의 District 이름으로 변환 */
     private String convertDistrictName(String name1, String name2) {
-        for (String city : SubwayIndexService.CITIES) {
+        for (String city : SubwayIndexDataService.CITIES) {
             if (name1.startsWith(city) && name2.endsWith("구"))
                 return name1 + name2;
         }

--- a/src/main/java/me/rentsignal/data/service/RentIndexDataService.java
+++ b/src/main/java/me/rentsignal/data/service/RentIndexDataService.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * 지수 데이터 (소비자 심리지수, 전월세 통합지수, 지하철 역세권 지수) 저장
  */
-public class RentIndexService {
+public class RentIndexDataService {
 
     @Value("${VILLA_RENT_INDEX_API_URL}")
     private String VILLA_RENT_INDEX_API_URL;

--- a/src/main/java/me/rentsignal/data/service/SentimentIndexDataService.java
+++ b/src/main/java/me/rentsignal/data/service/SentimentIndexDataService.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class SentimentIndexService {
+public class SentimentIndexDataService {
 
     private final ProvinceRepository provinceRepository;
     private final ProvinceIndexRepository provinceIndexRepository;

--- a/src/main/java/me/rentsignal/data/service/SubwayIndexDataService.java
+++ b/src/main/java/me/rentsignal/data/service/SubwayIndexDataService.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class SubwayIndexService {
+public class SubwayIndexDataService {
 
     @Value("${SUBWAY_ACCESSIBILITY_INDEX_API_URL}")
     private String SUBWAY_ACCESSIBILITY_INDEX_API_URL;

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
@@ -2,20 +2,14 @@ package me.rentsignal.locationInfo.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.response.BaseResponse;
-import me.rentsignal.locationInfo.dto.ConsumerSentimentIndexDto;
-import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
-import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
-import me.rentsignal.locationInfo.dto.SubwayAccessibilityIndexDto;
+import me.rentsignal.locationInfo.dto.*;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.service.ConsumerSentimentIndexService;
 import me.rentsignal.locationInfo.service.RentIndexService;
 import me.rentsignal.locationInfo.service.SubwayAccessibilityIndexService;
 import me.rentsignal.locationInfo.type.PeriodType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,6 +43,12 @@ public class LocationInfoController {
     public ResponseEntity<?> getSubwayAccessibilityIndex() {
         SubwayAccessibilityIndexDto subwayAccessibilityIndex = subwayAccessibilityIndexService.getSubwayAccessibilityIndex();
         return ResponseEntity.ok().body(BaseResponse.success(subwayAccessibilityIndex));
+    }
+
+    @GetMapping("/subway-accessibility/{districtId}")
+    public ResponseEntity<?> getSubwayStationByDistrict(@PathVariable Long districtId) {
+        DistrictSubwayDto subwayStationByDistrict = subwayAccessibilityIndexService.getSubwayStationByDistrict(districtId);
+        return ResponseEntity.ok().body(BaseResponse.success(subwayStationByDistrict));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
@@ -1,0 +1,36 @@
+package me.rentsignal.locationInfo.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.response.BaseResponse;
+import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
+import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
+import me.rentsignal.locationInfo.entity.HousingType;
+import me.rentsignal.locationInfo.service.RentIndexService;
+import me.rentsignal.locationInfo.type.PeriodType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/info")
+public class LocationInfoController {
+
+    private final RentIndexService rentIndexService;
+
+    @GetMapping("/rent-index/current")
+    public ResponseEntity<?> getCurrentRentIndex(@RequestParam HousingType housingType) {
+        CurrentRentIndexDto currentRentIndex = rentIndexService.getCurrentRentIndex(housingType);
+        return ResponseEntity.ok().body(BaseResponse.success(currentRentIndex));
+    }
+
+    @GetMapping("/rent-index/change")
+    public ResponseEntity<?> getRentIndexChange(@RequestParam HousingType housingType,
+                                                    @RequestParam PeriodType periodType) {
+        RentIndexChangeDto rentIndexChange = rentIndexService.getRentIndexChange(housingType, periodType);
+        return ResponseEntity.ok().body(BaseResponse.success(rentIndexChange));
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
@@ -5,9 +5,11 @@ import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.locationInfo.dto.ConsumerSentimentIndexDto;
 import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
 import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
+import me.rentsignal.locationInfo.dto.SubwayAccessibilityIndexDto;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.service.ConsumerSentimentIndexService;
 import me.rentsignal.locationInfo.service.RentIndexService;
+import me.rentsignal.locationInfo.service.SubwayAccessibilityIndexService;
 import me.rentsignal.locationInfo.type.PeriodType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +24,7 @@ public class LocationInfoController {
 
     private final RentIndexService rentIndexService;
     private final ConsumerSentimentIndexService consumerSentimentIndexService;
+    private final SubwayAccessibilityIndexService subwayAccessibilityIndexService;
 
     @GetMapping("/rent-index/current")
     public ResponseEntity<?> getCurrentRentIndex(@RequestParam HousingType housingType) {
@@ -40,6 +43,12 @@ public class LocationInfoController {
     public ResponseEntity<?> getConsumerSentimentIndex(@RequestParam PeriodType periodType) {
         ConsumerSentimentIndexDto consumerSentimentIndex = consumerSentimentIndexService.getConsumerSentimentIndex(periodType);
         return ResponseEntity.ok().body(BaseResponse.success(consumerSentimentIndex));
+    }
+
+    @GetMapping("/subway-accessibility")
+    public ResponseEntity<?> getSubwayAccessibilityIndex() {
+        SubwayAccessibilityIndexDto subwayAccessibilityIndex = subwayAccessibilityIndexService.getSubwayAccessibilityIndex();
+        return ResponseEntity.ok().body(BaseResponse.success(subwayAccessibilityIndex));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationInfoController.java
@@ -2,9 +2,11 @@ package me.rentsignal.locationInfo.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.response.BaseResponse;
+import me.rentsignal.locationInfo.dto.ConsumerSentimentIndexDto;
 import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
 import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
 import me.rentsignal.locationInfo.entity.HousingType;
+import me.rentsignal.locationInfo.service.ConsumerSentimentIndexService;
 import me.rentsignal.locationInfo.service.RentIndexService;
 import me.rentsignal.locationInfo.type.PeriodType;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LocationInfoController {
 
     private final RentIndexService rentIndexService;
+    private final ConsumerSentimentIndexService consumerSentimentIndexService;
 
     @GetMapping("/rent-index/current")
     public ResponseEntity<?> getCurrentRentIndex(@RequestParam HousingType housingType) {
@@ -31,6 +34,12 @@ public class LocationInfoController {
                                                     @RequestParam PeriodType periodType) {
         RentIndexChangeDto rentIndexChange = rentIndexService.getRentIndexChange(housingType, periodType);
         return ResponseEntity.ok().body(BaseResponse.success(rentIndexChange));
+    }
+
+    @GetMapping("/consumer-sentiment")
+    public ResponseEntity<?> getConsumerSentimentIndex(@RequestParam PeriodType periodType) {
+        ConsumerSentimentIndexDto consumerSentimentIndex = consumerSentimentIndexService.getConsumerSentimentIndex(periodType);
+        return ResponseEntity.ok().body(BaseResponse.success(consumerSentimentIndex));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/ConsumerSentimentIndexDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/ConsumerSentimentIndexDto.java
@@ -1,0 +1,19 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record ConsumerSentimentIndexDto(
+        List<MonthlyConsumerSentimentIndexDto> trend,
+        String year,
+        String month,
+        BigDecimal value
+) {
+
+    public record MonthlyConsumerSentimentIndexDto(
+            String yearMonth,
+            BigDecimal value
+    ) {
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/CurrentRentIndexDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/CurrentRentIndexDto.java
@@ -1,0 +1,8 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.util.List;
+
+public record CurrentRentIndexDto(
+        List<RentIndexItemDto> indexes
+) {
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/CurrentRentIndexDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/CurrentRentIndexDto.java
@@ -3,6 +3,6 @@ package me.rentsignal.locationInfo.dto;
 import java.util.List;
 
 public record CurrentRentIndexDto(
-        List<RentIndexItemDto> indexes
+        List<IndexItemDto> indexes
 ) {
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/DistrictSubwayDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/DistrictSubwayDto.java
@@ -1,0 +1,17 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record DistrictSubwayDto(
+        String name,
+        BigDecimal value,
+        List<SubwayStationDto> subwayStations
+) {
+
+    public record SubwayStationDto(
+            String lineName,
+            String stationName
+    ) {}
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/IndexItemDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/IndexItemDto.java
@@ -2,9 +2,9 @@ package me.rentsignal.locationInfo.dto;
 
 import java.math.BigDecimal;
 
-public record RentIndexItemDto(
+public record IndexItemDto(
         int rank,
-        String regionName,
+        String name,
         BigDecimal value
 ) {
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/RentIndexChangeDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/RentIndexChangeDto.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.util.List;
+
+public record RentIndexChangeDto(
+        List<RentIndexItemDto> rise,
+        List<RentIndexItemDto> fall
+) {
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/RentIndexChangeDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/RentIndexChangeDto.java
@@ -3,7 +3,7 @@ package me.rentsignal.locationInfo.dto;
 import java.util.List;
 
 public record RentIndexChangeDto(
-        List<RentIndexItemDto> rise,
-        List<RentIndexItemDto> fall
+        List<IndexItemDto> rise,
+        List<IndexItemDto> fall
 ) {
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/RentIndexItemDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/RentIndexItemDto.java
@@ -1,0 +1,10 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.math.BigDecimal;
+
+public record RentIndexItemDto(
+        int rank,
+        String regionName,
+        BigDecimal value
+) {
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/SubwayAccessibilityIndexDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/SubwayAccessibilityIndexDto.java
@@ -1,0 +1,16 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record SubwayAccessibilityIndexDto(
+        List<IndexItemDto> high,
+        List<IndexItemDto> changeRate,
+        List<DistrictIndexDto> districtIndexes
+) {
+    public record DistrictIndexDto(
+            Long id,
+            String name,
+            BigDecimal value
+    ) {}
+}

--- a/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DistrictIndexRepository extends JpaRepository<DistrictIndex, Long> {
     List<DistrictIndex> findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc(String provinceName, String baseYearMonth);
+    Optional<DistrictIndex> findByDistrict_IdAndBaseYearMonth(Long districtId, String baseYearMonth);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
@@ -4,6 +4,9 @@ import me.rentsignal.locationInfo.entity.DistrictIndex;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DistrictIndexRepository extends JpaRepository<DistrictIndex, Long> {
+    List<DistrictIndex> findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc(String provinceName, String baseYearMonth);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
@@ -1,10 +1,14 @@
 package me.rentsignal.locationInfo.repository;
 
 import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
+import me.rentsignal.locationInfo.entity.TransportType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository
 public interface NeighborhoodTransportRepository extends JpaRepository<NeighborhoodTransport, Long> {
+    List<NeighborhoodTransport> findByNeighborhood_District_IdAndTransportType(Long id, TransportType type);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/ProvinceIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/ProvinceIndexRepository.java
@@ -4,6 +4,11 @@ import me.rentsignal.locationInfo.entity.ProvinceIndex;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface ProvinceIndexRepository extends JpaRepository<ProvinceIndex, Long> {
+    Optional<ProvinceIndex> findByProvince_NameAndBaseYearMonth(String name, String baseYearMonth);
+    List<ProvinceIndex> findByProvince_NameAndBaseYearMonthBetweenOrderByBaseYearMonthAsc(String name, String start, String end);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/RegionIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/RegionIndexRepository.java
@@ -1,9 +1,14 @@
 package me.rentsignal.locationInfo.repository;
 
+import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RegionIndexRepository extends JpaRepository<RegionIndex, Long> {
+    List<RegionIndex> findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(HousingType housingType, String baseYearMonth);
+    List<RegionIndex> findByHousingTypeAndBaseYearMonth(HousingType housingType, String baseYearMonth);
 }

--- a/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
@@ -35,7 +35,7 @@ public class ConsumerSentimentIndexService {
 
         BigDecimal value;
         if (periodType == PeriodType.CURRENT) {
-            value = baseValue;
+            value = baseValue.setScale(1, RoundingMode.HALF_UP);
         } else {
             ProvinceIndex comparisonIndex = provinceIndexRepository.findByProvince_NameAndBaseYearMonth("서울특별시", formattedYearMonth).orElse(null);
             BigDecimal comparisonValue = (comparisonIndex != null) ? comparisonIndex.getConsumerSentimentIndex() : BigDecimal.ZERO;
@@ -49,7 +49,7 @@ public class ConsumerSentimentIndexService {
                 trend,
                 formattedYearMonth.substring(0, 4),
                 formattedYearMonth.substring(4),
-                value.setScale(1, RoundingMode.HALF_UP)
+                value
         );
     }
 

--- a/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
@@ -1,0 +1,77 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.locationInfo.dto.ConsumerSentimentIndexDto;
+import me.rentsignal.locationInfo.entity.ProvinceIndex;
+import me.rentsignal.locationInfo.repository.ProvinceIndexRepository;
+import me.rentsignal.locationInfo.type.PeriodType;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumerSentimentIndexService {
+
+    private final ProvinceIndexRepository provinceIndexRepository;
+    private final LocationInfoService locationInfoService;
+
+    // 현재는 서울특별시 데이터만 반환
+    public ConsumerSentimentIndexDto getConsumerSentimentIndex(PeriodType periodType) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+
+        // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
+        YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
+        YearMonth yearMonth = periodType.toComparisonYearMonth(baseYearMonth);
+
+        String formattedYearMonth = yearMonth.format(formatter);
+        ProvinceIndex baseIndex = provinceIndexRepository.findByProvince_NameAndBaseYearMonth("서울특별시", baseYearMonth.format(formatter)).orElse(null);
+        BigDecimal baseValue = (baseIndex != null) ? baseIndex.getConsumerSentimentIndex() : BigDecimal.ZERO;
+
+        BigDecimal value;
+        if (periodType == PeriodType.CURRENT) {
+            value = baseValue;
+        } else {
+            ProvinceIndex comparisonIndex = provinceIndexRepository.findByProvince_NameAndBaseYearMonth("서울특별시", formattedYearMonth).orElse(null);
+            BigDecimal comparisonValue = (comparisonIndex != null) ? comparisonIndex.getConsumerSentimentIndex() : BigDecimal.ZERO;
+
+            value = locationInfoService.calculateChangeRate(baseValue, comparisonValue);
+        }
+
+        List<ConsumerSentimentIndexDto.MonthlyConsumerSentimentIndexDto> trend = getConsumerSentimentIndexTrend(baseYearMonth);
+
+        return new ConsumerSentimentIndexDto(
+                trend,
+                formattedYearMonth.substring(0, 4),
+                formattedYearMonth.substring(4),
+                value.setScale(1, RoundingMode.HALF_UP)
+        );
+    }
+
+    /** baseYearMonth로부터 6개월 전까지의 데이터 조회 */
+    private List<ConsumerSentimentIndexDto.MonthlyConsumerSentimentIndexDto> getConsumerSentimentIndexTrend(YearMonth baseYearMonth) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+        String end = baseYearMonth.format(formatter);
+        String start = baseYearMonth.minusMonths(6).format(formatter);
+
+        List<ProvinceIndex> indexes = provinceIndexRepository.findByProvince_NameAndBaseYearMonthBetweenOrderByBaseYearMonthAsc("서울특별시", start, end);
+
+        List<ConsumerSentimentIndexDto.MonthlyConsumerSentimentIndexDto> list = new ArrayList<>();
+        for (ProvinceIndex index : indexes) {
+            list.add(
+                    new ConsumerSentimentIndexDto.MonthlyConsumerSentimentIndexDto(
+                            index.getBaseYearMonth().substring(0, 4) + ". " + index.getBaseYearMonth().substring(4),
+                            index.getConsumerSentimentIndex().setScale(1, RoundingMode.HALF_UP)
+                    )
+            );
+        }
+
+        return list;
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/LocationInfoService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/LocationInfoService.java
@@ -1,0 +1,21 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Service
+@RequiredArgsConstructor
+public class LocationInfoService {
+
+    public BigDecimal calculateChangeRate(BigDecimal baseValue, BigDecimal comparisonValue) {
+        return baseValue
+                .subtract(comparisonValue)
+                .divide(comparisonValue, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(1, RoundingMode.HALF_UP);
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/LocationInfoService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/LocationInfoService.java
@@ -15,7 +15,7 @@ public class LocationInfoService {
                 .subtract(comparisonValue)
                 .divide(comparisonValue, 4, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100))
-                .setScale(1, RoundingMode.HALF_UP);
+                .setScale(2, RoundingMode.HALF_UP);
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -1,6 +1,8 @@
 package me.rentsignal.locationInfo.service;
 
 import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
 import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
 import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
 import me.rentsignal.locationInfo.dto.RentIndexItemDto;
@@ -52,11 +54,10 @@ public class RentIndexService {
     public RentIndexChangeDto getRentIndexChange(HousingType housingType, PeriodType periodType) {
         YearMonth baseYearMonth = YearMonth.now().minusMonths(1);
 
-        YearMonth comparisonYearMonth = switch (periodType) {
-            case ONE_YEAR -> baseYearMonth.minusYears(1);
-            case SIX_MONTH -> baseYearMonth.minusMonths(6);
-            case ONE_MONTH -> baseYearMonth.minusMonths(1);
-        };
+        if (periodType == PeriodType.CURRENT) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE, "해당 periodType을 지원하지 않습니다.");
+        }
+        YearMonth comparisonYearMonth = periodType.toComparisonYearMonth(baseYearMonth);
 
         List<RegionIndex> baseIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, baseYearMonth.format(formatter));
         List<RegionIndex> comparisonIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, comparisonYearMonth.format(formatter));

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -29,6 +29,7 @@ public class RentIndexService {
     private final RegionIndexRepository regionIndexRepository;
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+    private final LocationInfoService locationInfoService;
 
     public CurrentRentIndexDto getCurrentRentIndex(HousingType housingType) {
         // 데이터가 1개월 지연되어 제공되기 때문에 1개월 전 데이터 사용
@@ -81,11 +82,7 @@ public class RentIndexService {
             BigDecimal comparisonValue = comparisonIndex.getRentCompositeIndex();
 
             // 증감률 계산
-            BigDecimal changeRate = baseValue
-                    .subtract(comparisonValue)
-                    .divide(comparisonValue, 4, RoundingMode.HALF_UP)
-                    .multiply(BigDecimal.valueOf(100))
-                    .setScale(1, RoundingMode.HALF_UP);
+            BigDecimal changeRate = locationInfoService.calculateChangeRate(baseValue, comparisonValue);
 
             // 증감률이 양수이면 riseList에, 음수이면 fallList에, 0이면 제외
             if (changeRate.compareTo(BigDecimal.ZERO) > 0) {

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -5,7 +5,7 @@ import me.rentsignal.global.exception.BaseException;
 import me.rentsignal.global.exception.ErrorCode;
 import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
 import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
-import me.rentsignal.locationInfo.dto.RentIndexItemDto;
+import me.rentsignal.locationInfo.dto.IndexItemDto;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import me.rentsignal.locationInfo.repository.RegionIndexRepository;
@@ -37,10 +37,10 @@ public class RentIndexService {
 
         List<RegionIndex> indexes = regionIndexRepository.findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(housingType, now.format(formatter));
 
-        List<RentIndexItemDto> list = new ArrayList<>();
+        List<IndexItemDto> list = new ArrayList<>();
         int i = 1;
         for (RegionIndex index : indexes) {
-            list.add(new RentIndexItemDto(
+            list.add(new IndexItemDto(
 
                     i,
                     getRegionName(index),
@@ -68,8 +68,8 @@ public class RentIndexService {
                         index -> index.getRegion().getId(),
                         index -> index));
 
-        List<RentIndexItemDto> riseList = new ArrayList<>();
-        List<RentIndexItemDto> fallList = new ArrayList<>();
+        List<IndexItemDto> riseList = new ArrayList<>();
+        List<IndexItemDto> fallList = new ArrayList<>();
         for (RegionIndex baseIndex : baseIndexes) {
             // comparisonIndexes에 해당 id의 region의 regionIndex가 존재하는지 확인
             RegionIndex comparisonIndex = comparisonIndexMap.get(baseIndex.getRegion().getId());
@@ -86,26 +86,26 @@ public class RentIndexService {
 
             // 증감률이 양수이면 riseList에, 음수이면 fallList에, 0이면 제외
             if (changeRate.compareTo(BigDecimal.ZERO) > 0) {
-                riseList.add(new RentIndexItemDto(
+                riseList.add(new IndexItemDto(
                         0,   // 순위는 임시로 0
                         getRegionName(baseIndex),
                         changeRate));
             } else if (changeRate.compareTo(BigDecimal.ZERO) < 0) {
-                fallList.add(new RentIndexItemDto(
+                fallList.add(new IndexItemDto(
                         0,
                         getRegionName(baseIndex),
                         changeRate));
             }
         }
 
-        List<RentIndexItemDto> sortedRiseList = riseList.stream()
+        List<IndexItemDto> sortedRiseList = riseList.stream()
                 .sorted(
-                        Comparator.comparing(RentIndexItemDto::value)
+                        Comparator.comparing(IndexItemDto::value)
                                 .reversed()).toList();
-        List<RentIndexItemDto> sortedFallList = fallList.stream()
+        List<IndexItemDto> sortedFallList = fallList.stream()
                 .sorted(
                         Comparator.comparing(
-                                RentIndexItemDto::value)
+                                IndexItemDto::value)
                 ).toList();
 
         return new RentIndexChangeDto(
@@ -119,15 +119,15 @@ public class RentIndexService {
     }
 
     /** 정렬된 RentIndexItemDto 리스트 각 요소에 rank 반영해서 새로운 리스트 반환 */
-    private List<RentIndexItemDto> getRankedList(List<RentIndexItemDto> sortedList) {
-        List<RentIndexItemDto> rankedList = new ArrayList<>();
+    private List<IndexItemDto> getRankedList(List<IndexItemDto> sortedList) {
+        List<IndexItemDto> rankedList = new ArrayList<>();
 
         for (int i = 0; i < sortedList.size(); i++) {
-            RentIndexItemDto item = sortedList.get(i);
+            IndexItemDto item = sortedList.get(i);
 
-            rankedList.add(new RentIndexItemDto(
+            rankedList.add(new IndexItemDto(
                     i+1,
-                    item.regionName(),
+                    item.name(),
                     item.value()
             ));
         }

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -1,0 +1,140 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
+import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
+import me.rentsignal.locationInfo.dto.RentIndexItemDto;
+import me.rentsignal.locationInfo.entity.HousingType;
+import me.rentsignal.locationInfo.entity.RegionIndex;
+import me.rentsignal.locationInfo.repository.RegionIndexRepository;
+import me.rentsignal.locationInfo.type.PeriodType;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RentIndexService {
+
+    private final RegionIndexRepository regionIndexRepository;
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+
+    public CurrentRentIndexDto getCurrentRentIndex(HousingType housingType) {
+        // 데이터가 1개월 지연되어 제공되기 때문에 1개월 전 데이터 사용
+        YearMonth now = YearMonth.now().minusMonths(1);
+
+        List<RegionIndex> indexes = regionIndexRepository.findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(housingType, now.format(formatter));
+
+        List<RentIndexItemDto> list = new ArrayList<>();
+        int i = 1;
+        for (RegionIndex index : indexes) {
+            list.add(new RentIndexItemDto(
+
+                    i,
+                    getRegionName(index),
+                    index.getRentCompositeIndex().setScale(1, RoundingMode.HALF_UP)
+            ));
+            i++;
+        }
+
+        return new CurrentRentIndexDto(list);
+    }
+
+    public RentIndexChangeDto getRentIndexChange(HousingType housingType, PeriodType periodType) {
+        YearMonth baseYearMonth = YearMonth.now().minusMonths(1);
+
+        YearMonth comparisonYearMonth = switch (periodType) {
+            case ONE_YEAR -> baseYearMonth.minusYears(1);
+            case SIX_MONTH -> baseYearMonth.minusMonths(6);
+            case ONE_MONTH -> baseYearMonth.minusMonths(1);
+        };
+
+        List<RegionIndex> baseIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, baseYearMonth.format(formatter));
+        List<RegionIndex> comparisonIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, comparisonYearMonth.format(formatter));
+
+        Map<Long, RegionIndex> comparisonIndexMap = comparisonIndexes.stream()
+                .collect(Collectors.toMap(
+                        index -> index.getRegion().getId(),
+                        index -> index));
+
+        List<RentIndexItemDto> riseList = new ArrayList<>();
+        List<RentIndexItemDto> fallList = new ArrayList<>();
+        for (RegionIndex baseIndex : baseIndexes) {
+            // comparisonIndexes에 해당 id의 region의 regionIndex가 존재하는지 확인
+            RegionIndex comparisonIndex = comparisonIndexMap.get(baseIndex.getRegion().getId());
+
+            if (comparisonIndex == null) {
+                continue;
+            }
+
+            BigDecimal baseValue = baseIndex.getRentCompositeIndex();
+            BigDecimal comparisonValue = comparisonIndex.getRentCompositeIndex();
+
+            // 증감률 계산
+            BigDecimal changeRate = baseValue
+                    .subtract(comparisonValue)
+                    .divide(comparisonValue, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100))
+                    .setScale(1, RoundingMode.HALF_UP);
+
+            // 증감률이 양수이면 riseList에, 음수이면 fallList에, 0이면 제외
+            if (changeRate.compareTo(BigDecimal.ZERO) > 0) {
+                riseList.add(new RentIndexItemDto(
+                        0,   // 순위는 임시로 0
+                        getRegionName(baseIndex),
+                        changeRate));
+            } else if (changeRate.compareTo(BigDecimal.ZERO) < 0) {
+                fallList.add(new RentIndexItemDto(
+                        0,
+                        getRegionName(baseIndex),
+                        changeRate));
+            }
+        }
+
+        List<RentIndexItemDto> sortedRiseList = riseList.stream()
+                .sorted(
+                        Comparator.comparing(RentIndexItemDto::value)
+                                .reversed()).toList();
+        List<RentIndexItemDto> sortedFallList = fallList.stream()
+                .sorted(
+                        Comparator.comparing(
+                                RentIndexItemDto::value)
+                ).toList();
+
+        return new RentIndexChangeDto(
+                getRankedList(sortedRiseList),
+                getRankedList(sortedFallList)
+        );
+    }
+
+    private String getRegionName(RegionIndex index) {
+        return index.getRegion().getAreaGroup() + " " + index.getRegion().getAreaName();
+    }
+
+    /** 정렬된 RentIndexItemDto 리스트 각 요소에 rank 반영해서 새로운 리스트 반환 */
+    private List<RentIndexItemDto> getRankedList(List<RentIndexItemDto> sortedList) {
+        List<RentIndexItemDto> rankedList = new ArrayList<>();
+
+        for (int i = 0; i < sortedList.size(); i++) {
+            RentIndexItemDto item = sortedList.get(i);
+
+            rankedList.add(new RentIndexItemDto(
+                    i+1,
+                    item.regionName(),
+                    item.value()
+            ));
+        }
+
+        return rankedList;
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -27,9 +27,9 @@ import java.util.stream.Collectors;
 public class RentIndexService {
 
     private final RegionIndexRepository regionIndexRepository;
+    private final LocationInfoService locationInfoService;
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-    private final LocationInfoService locationInfoService;
 
     public CurrentRentIndexDto getCurrentRentIndex(HousingType housingType) {
         // 데이터가 1개월 지연되어 제공되기 때문에 1개월 전 데이터 사용

--- a/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
@@ -1,0 +1,100 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.locationInfo.dto.IndexItemDto;
+import me.rentsignal.locationInfo.dto.SubwayAccessibilityIndexDto;
+import me.rentsignal.locationInfo.entity.DistrictIndex;
+import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SubwayAccessibilityIndexService {
+
+    private final DistrictIndexRepository districtIndexRepository;
+    private final LocationInfoService locationInfoService;
+
+    public SubwayAccessibilityIndexDto getSubwayAccessibilityIndex() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+
+        // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
+        YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
+        YearMonth comparisonYearMonth = baseYearMonth.minusMonths(6);
+
+        String base = baseYearMonth.format(formatter);
+        String comparison = comparisonYearMonth.format(formatter);
+
+        // 서울특별시 데이터의 당월, 6개월 전 데이터 조회
+        List<DistrictIndex> currentIndexes = districtIndexRepository.findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc("서울특별시", base);
+        List<DistrictIndex> previousIndexes = districtIndexRepository.findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc("서울특별시", comparison);
+
+        // districtId 기준으로 6개월 전 인덱스를 빠르게 조회하기 위한 맵
+        Map<Long, DistrictIndex> previousIndexMap = previousIndexes.stream()
+                .collect(Collectors.toMap(
+                        index -> index.getDistrict().getId(),
+                        index -> index
+                ));
+
+        List<SubwayAccessibilityIndexDto.DistrictIndexDto> indexes = new ArrayList<>();
+        List<IndexItemDto> high = new ArrayList<>();
+        List<IndexItemDto> changeRate = new ArrayList<>();
+        int i = 1;
+        for (DistrictIndex districtIndex : currentIndexes) {
+            Long districtId = districtIndex.getDistrict().getId();
+            String districtName = districtIndex.getDistrict().getName();
+            // 각 District별 지수 데이터 DTO
+            indexes.add(new SubwayAccessibilityIndexDto.DistrictIndexDto(
+                    districtId,
+                    districtName,
+                    districtIndex.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP)
+            ));
+            // 당월 지하철 역세권 지수 내림차순
+            high.add(new IndexItemDto(
+                    i,
+                    districtName,
+                    districtIndex.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP)
+            ));
+            i++;
+            // 6개월 전 기준 지수 증감률 내림차순
+            DistrictIndex previousIndex = previousIndexMap.get(districtId);
+            if (previousIndex == null) {
+                continue;
+            }
+
+            BigDecimal rate = locationInfoService.calculateChangeRate(districtIndex.getSubwayAccessibilityIndex(),
+                    previousIndex.getSubwayAccessibilityIndex());
+            changeRate.add(new IndexItemDto(0,
+                    districtName,
+                    rate.setScale(1, RoundingMode.HALF_UP)));
+        }
+
+        changeRate.sort((a, b) -> b.value().compareTo(a.value()));
+
+        List<IndexItemDto> rankedchangeRate = new ArrayList<>();
+        for (int j = 0; j < changeRate.size(); j++) {
+            IndexItemDto item = changeRate.get(j);
+
+            rankedchangeRate.add(new IndexItemDto(
+                    j + 1,
+                    item.name(),
+                    item.value()
+            ));
+        }
+
+        return new SubwayAccessibilityIndexDto(
+                high,
+                rankedchangeRate,
+                indexes
+        );
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
@@ -1,10 +1,18 @@
 package me.rentsignal.locationInfo.service;
 
 import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.District;
+import me.rentsignal.location.repository.DistrictRepository;
+import me.rentsignal.locationInfo.dto.DistrictSubwayDto;
 import me.rentsignal.locationInfo.dto.IndexItemDto;
 import me.rentsignal.locationInfo.dto.SubwayAccessibilityIndexDto;
 import me.rentsignal.locationInfo.entity.DistrictIndex;
+import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
+import me.rentsignal.locationInfo.entity.TransportType;
 import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
+import me.rentsignal.locationInfo.repository.NeighborhoodTransportRepository;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -22,10 +30,12 @@ public class SubwayAccessibilityIndexService {
 
     private final DistrictIndexRepository districtIndexRepository;
     private final LocationInfoService locationInfoService;
+    private final DistrictRepository districtRepository;
+    private final NeighborhoodTransportRepository neighborhoodTransportRepository;
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
 
     public SubwayAccessibilityIndexDto getSubwayAccessibilityIndex() {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-
         // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
         YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
         YearMonth comparisonYearMonth = baseYearMonth.minusMonths(6);
@@ -74,16 +84,16 @@ public class SubwayAccessibilityIndexService {
                     previousIndex.getSubwayAccessibilityIndex());
             changeRate.add(new IndexItemDto(0,
                     districtName,
-                    rate.setScale(1, RoundingMode.HALF_UP)));
+                    rate));
         }
 
         changeRate.sort((a, b) -> b.value().compareTo(a.value()));
 
-        List<IndexItemDto> rankedchangeRate = new ArrayList<>();
+        List<IndexItemDto> rankedChangeRate = new ArrayList<>();
         for (int j = 0; j < changeRate.size(); j++) {
             IndexItemDto item = changeRate.get(j);
 
-            rankedchangeRate.add(new IndexItemDto(
+            rankedChangeRate.add(new IndexItemDto(
                     j + 1,
                     item.name(),
                     item.value()
@@ -92,8 +102,36 @@ public class SubwayAccessibilityIndexService {
 
         return new SubwayAccessibilityIndexDto(
                 high,
-                rankedchangeRate,
+                rankedChangeRate,
                 indexes
+        );
+    }
+
+    public DistrictSubwayDto getSubwayStationByDistrict(Long districtId) {
+        District district = districtRepository.findById(districtId).orElseThrow(
+                () -> new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 id의 시/군/구가 존재하지 않습니다."));
+
+        List<NeighborhoodTransport> neighborhoodTransports = neighborhoodTransportRepository.findByNeighborhood_District_IdAndTransportType(districtId, TransportType.SUBWAY_STATION);
+        List<DistrictSubwayDto.SubwayStationDto> subwayStations = new ArrayList<>();
+        for (NeighborhoodTransport transport : neighborhoodTransports) {
+            String name = transport.getName();
+            String[] arr = name.split("\\|");
+            String stationName = arr[0];
+            String lineName = arr[1];
+            subwayStations.add(new DistrictSubwayDto.SubwayStationDto(
+                    lineName,
+                    stationName
+            ));
+        }
+
+        YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
+        DistrictIndex index = districtIndexRepository.findByDistrict_IdAndBaseYearMonth(districtId, baseYearMonth.format(formatter)).orElse(null);
+        BigDecimal value = (index != null) ? index.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP) : BigDecimal.ZERO;
+
+        return new DistrictSubwayDto(
+                district.getName(),
+                value,
+                subwayStations
         );
     }
 

--- a/src/main/java/me/rentsignal/locationInfo/type/PeriodType.java
+++ b/src/main/java/me/rentsignal/locationInfo/type/PeriodType.java
@@ -1,0 +1,7 @@
+package me.rentsignal.locationInfo.type;
+
+public enum PeriodType {
+    ONE_YEAR,
+    SIX_MONTH,
+    ONE_MONTH
+}

--- a/src/main/java/me/rentsignal/locationInfo/type/PeriodType.java
+++ b/src/main/java/me/rentsignal/locationInfo/type/PeriodType.java
@@ -1,7 +1,20 @@
 package me.rentsignal.locationInfo.type;
 
+import java.time.YearMonth;
+
 public enum PeriodType {
     ONE_YEAR,
     SIX_MONTH,
-    ONE_MONTH
+    ONE_MONTH,
+    CURRENT;
+
+    /** periodType에 따라 comparisonYearMonth 계산 */
+    public YearMonth toComparisonYearMonth(YearMonth baseYearMonth) {
+        return switch (this) {
+            case ONE_YEAR -> baseYearMonth.minusYears(1);
+            case SIX_MONTH -> baseYearMonth.minusMonths(6);
+            case ONE_MONTH -> baseYearMonth.minusMonths(1);
+            case CURRENT -> baseYearMonth;
+        };
+    }
 }


### PR DESCRIPTION
## ✅ 관련 이슈
closed #33 

## ✨ 작업 내용
- 전월세 통합지수 조회 구현
`/current`인 경우 전월세 통합지수 값 기준 내림차순 리스트
`/change`인 경우 periodType 시기 대비 당월 전월세 통합지수 급상승, 급하락 리스트
- 소비자 심리지수 조회 구현
`periodType == CURRENT`인 경우 당월의 소비자 심리지수 값, 최근 7개월 동안의 소비자 심리지수 추이 리스트 반환
`periodType == ONE_MONTH, SIX_MONTH, ONE_YEAR`인 경우 해당 시기 대비 당월 소비자 심리지수 증감률, 최근 7개월 동안의 소비자 심리지수 추이 리스트 반환
- 지하철 역세권 지수 조회 구현
역세권 지수 내림차순 리스트, 6개월 전과 당월 지수 증감률 내림차순 리스트, 구별 id와 역세권 지수 리스트
- 특정 구의 지하철역 목록 조회 구현

## 📸 스크린샷


## 🗨️ 참고 사항
