### PR TITLE
[Feat] 교통 제외 정보탭 생활요소 중심 데이터 조회 기능 구현

### DIFF
--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationIndexController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationIndexController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/info")
-public class LocationInfoController {
+public class LocationIndexController {
 
     private final RentIndexService rentIndexService;
     private final ConsumerSentimentIndexService consumerSentimentIndexService;

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
@@ -1,0 +1,25 @@
+package me.rentsignal.locationInfo.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.response.BaseResponse;
+import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
+import me.rentsignal.locationInfo.service.ConvenienceService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/info")
+public class LocationLivingFactorController {
+
+    private final ConvenienceService convenienceService;
+
+    @GetMapping("/convenience")
+    public ResponseEntity<?> getConvenienceRanking() {
+        ConvenienceRankDto convenienceRanking = convenienceService.getConvenienceRanking();
+        return ResponseEntity.ok().body(BaseResponse.success(convenienceRanking));
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
 import me.rentsignal.locationInfo.dto.ConvenienceTypeCountDto;
+import me.rentsignal.locationInfo.dto.DistrictSafetyDto;
 import me.rentsignal.locationInfo.service.ConvenienceService;
+import me.rentsignal.locationInfo.service.SafetyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LocationLivingFactorController {
 
     private final ConvenienceService convenienceService;
+    private final SafetyService safetyService;
 
     @GetMapping("/convenience")
     public ResponseEntity<?> getConvenienceRanking() {
@@ -28,6 +31,12 @@ public class LocationLivingFactorController {
     public ResponseEntity<?> getConvenienceRanking(@PathVariable Long neighborhoodId) {
         ConvenienceTypeCountDto convenienceTypeCount = convenienceService.getConvenienceTypeCount(neighborhoodId);
         return ResponseEntity.ok().body(BaseResponse.success(convenienceTypeCount));
+    }
+
+    @GetMapping("/safety")
+    public ResponseEntity<?> getSafety() {
+        DistrictSafetyDto safety = safetyService.getSafety();
+        return ResponseEntity.ok().body(BaseResponse.success(safety));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
@@ -3,9 +3,11 @@ package me.rentsignal.locationInfo.controller;
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
+import me.rentsignal.locationInfo.dto.ConvenienceTypeCountDto;
 import me.rentsignal.locationInfo.service.ConvenienceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +22,12 @@ public class LocationLivingFactorController {
     public ResponseEntity<?> getConvenienceRanking() {
         ConvenienceRankDto convenienceRanking = convenienceService.getConvenienceRanking();
         return ResponseEntity.ok().body(BaseResponse.success(convenienceRanking));
+    }
+
+    @GetMapping("/convenience/{neighborhoodId}")
+    public ResponseEntity<?> getConvenienceRanking(@PathVariable Long neighborhoodId) {
+        ConvenienceTypeCountDto convenienceTypeCount = convenienceService.getConvenienceTypeCount(neighborhoodId);
+        return ResponseEntity.ok().body(BaseResponse.success(convenienceTypeCount));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/ConvenienceRankDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/ConvenienceRankDto.java
@@ -1,0 +1,17 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.util.List;
+
+public record ConvenienceRankDto(
+        List<NeighborhoodConvenienceCountDto> ranking
+) {
+
+    public record NeighborhoodConvenienceCountDto(
+            int rank,
+            Long id,
+            String name,
+            Long count
+    ) {
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/ConvenienceRankDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/ConvenienceRankDto.java
@@ -3,10 +3,10 @@ package me.rentsignal.locationInfo.dto;
 import java.util.List;
 
 public record ConvenienceRankDto(
-        List<NeighborhoodConvenienceCountDto> ranking
+        List<NeighborhoodConvenienceRankDto> ranking
 ) {
 
-    public record NeighborhoodConvenienceCountDto(
+    public record NeighborhoodConvenienceRankDto(
             int rank,
             Long id,
             String name,

--- a/src/main/java/me/rentsignal/locationInfo/dto/ConvenienceTypeCountDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/ConvenienceTypeCountDto.java
@@ -1,0 +1,26 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.util.List;
+
+public record ConvenienceTypeCountDto (
+        String name,
+        ConvenienceGroupDto mart,
+        ConvenienceGroupDto convenienceStore,
+        ConvenienceGroupDto hospital,
+        ConvenienceGroupDto cafe
+) {
+
+    // Type별 NeighborhoodConvenience
+    public record ConvenienceGroupDto (
+            int count,
+            List<ConvenienceDto> conveniences
+    ) {}
+
+    // 개별 NeighborhoodConvenience
+    public record ConvenienceDto(
+            String name,
+            Double latitude,
+            Double longitude
+    ) {}
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/CurrentRentIndexDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/CurrentRentIndexDto.java
@@ -3,6 +3,6 @@ package me.rentsignal.locationInfo.dto;
 import java.util.List;
 
 public record CurrentRentIndexDto(
-        List<IndexItemDto> indexes
+        List<RankItemDto> indexes
 ) {
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/DistrictSafetyDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/DistrictSafetyDto.java
@@ -1,0 +1,16 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record DistrictSafetyDto(
+        List<RankItemDto> ranking,
+        List<DistrictSafetyScoreDto> districtSafetyScores
+) {
+
+    public record DistrictSafetyScoreDto(
+            String name,
+            BigDecimal value
+    ) {}
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/NeighborhoodConvenienceQueryDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/NeighborhoodConvenienceQueryDto.java
@@ -1,0 +1,8 @@
+package me.rentsignal.locationInfo.dto;
+
+public record NeighborhoodConvenienceQueryDto(
+        Long id,
+        String name,
+        Long count
+) {
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/RankItemDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/RankItemDto.java
@@ -2,7 +2,7 @@ package me.rentsignal.locationInfo.dto;
 
 import java.math.BigDecimal;
 
-public record IndexItemDto(
+public record RankItemDto(
         int rank,
         String name,
         BigDecimal value

--- a/src/main/java/me/rentsignal/locationInfo/dto/RentIndexChangeDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/RentIndexChangeDto.java
@@ -3,7 +3,7 @@ package me.rentsignal.locationInfo.dto;
 import java.util.List;
 
 public record RentIndexChangeDto(
-        List<IndexItemDto> rise,
-        List<IndexItemDto> fall
+        List<RankItemDto> rise,
+        List<RankItemDto> fall
 ) {
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/SubwayAccessibilityIndexDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/SubwayAccessibilityIndexDto.java
@@ -4,8 +4,8 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public record SubwayAccessibilityIndexDto(
-        List<IndexItemDto> high,
-        List<IndexItemDto> changeRate,
+        List<RankItemDto> high,
+        List<RankItemDto> changeRate,
         List<DistrictIndexDto> districtIndexes
 ) {
     public record DistrictIndexDto(

--- a/src/main/java/me/rentsignal/locationInfo/repository/DistrictSafetyRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/DistrictSafetyRepository.java
@@ -4,6 +4,9 @@ import me.rentsignal.locationInfo.entity.DistrictSafety;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DistrictSafetyRepository extends JpaRepository<DistrictSafety, Long> {
+    List<DistrictSafety> findByDistrict_Province_NameOrderBySafetyScoreDesc(String provinceName);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodConvenienceRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodConvenienceRepository.java
@@ -1,9 +1,27 @@
 package me.rentsignal.locationInfo.repository;
 
+import me.rentsignal.locationInfo.dto.NeighborhoodConvenienceQueryDto;
 import me.rentsignal.locationInfo.entity.NeighborhoodConvenience;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface NeighborhoodConvenienceRepository extends JpaRepository<NeighborhoodConvenience, Long> {
+    @Query("""
+        SELECT new me.rentsignal.locationInfo.dto.NeighborhoodConvenienceQueryDto(
+            nc.neighborhood.id,
+            CONCAT(
+                nc.neighborhood.district.name, ' ', nc.neighborhood.name
+            ),
+            COUNT(nc)
+        )
+        FROM NeighborhoodConvenience nc
+        GROUP BY nc.neighborhood.id, nc.neighborhood.name, nc.neighborhood.district.name
+        ORDER BY COUNT(nc) DESC 
+    """)
+    List<NeighborhoodConvenienceQueryDto> findTopNeighborhoodConvenienceCount(Pageable pageable);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodConvenienceRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodConvenienceRepository.java
@@ -1,6 +1,7 @@
 package me.rentsignal.locationInfo.repository;
 
 import me.rentsignal.locationInfo.dto.NeighborhoodConvenienceQueryDto;
+import me.rentsignal.locationInfo.entity.ConvenienceType;
 import me.rentsignal.locationInfo.entity.NeighborhoodConvenience;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,5 @@ public interface NeighborhoodConvenienceRepository extends JpaRepository<Neighbo
         ORDER BY COUNT(nc) DESC 
     """)
     List<NeighborhoodConvenienceQueryDto> findTopNeighborhoodConvenienceCount(Pageable pageable);
+    List<NeighborhoodConvenience> findByNeighborhood_IdAndType(Long id, ConvenienceType type);
 }

--- a/src/main/java/me/rentsignal/locationInfo/service/ConvenienceService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConvenienceService.java
@@ -1,8 +1,14 @@
 package me.rentsignal.locationInfo.service;
 
 import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.Neighborhood;
+import me.rentsignal.location.repository.NeighborhoodRepository;
 import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
+import me.rentsignal.locationInfo.dto.ConvenienceTypeCountDto;
 import me.rentsignal.locationInfo.dto.NeighborhoodConvenienceQueryDto;
+import me.rentsignal.locationInfo.entity.ConvenienceType;
 import me.rentsignal.locationInfo.repository.NeighborhoodConvenienceRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -15,18 +21,19 @@ import java.util.List;
 public class ConvenienceService {
 
     private final NeighborhoodConvenienceRepository neighborhoodConvenienceRepository;
+    private final NeighborhoodRepository neighborhoodRepository;
 
     public ConvenienceRankDto getConvenienceRanking() {
         List<NeighborhoodConvenienceQueryDto> topNeighborhoodConvenienceCount = neighborhoodConvenienceRepository.findTopNeighborhoodConvenienceCount(PageRequest.of(0, 7));
 
-        List<ConvenienceRankDto.NeighborhoodConvenienceCountDto> ranking = new ArrayList<>();
+        List<ConvenienceRankDto.NeighborhoodConvenienceRankDto> ranking = new ArrayList<>();
         int i = 1;
         for (NeighborhoodConvenienceQueryDto dto : topNeighborhoodConvenienceCount) {
             Long neighborhoodId = dto.id();
             String name = dto.name();
             Long count = dto.count();
 
-            ranking.add(new ConvenienceRankDto.NeighborhoodConvenienceCountDto(
+            ranking.add(new ConvenienceRankDto.NeighborhoodConvenienceRankDto(
                     i,
                     neighborhoodId,
                     name,
@@ -36,6 +43,37 @@ public class ConvenienceService {
         }
 
         return new ConvenienceRankDto(ranking);
+    }
+
+    public ConvenienceTypeCountDto getConvenienceTypeCount(Long neighborhoodId) {
+        Neighborhood neighborhood = neighborhoodRepository.findById(neighborhoodId).orElseThrow(
+                () -> new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 id의 읍/면/동이 존재하지 않습니다."));
+
+        return new ConvenienceTypeCountDto(
+                neighborhood.getDistrict().getName() + " " + neighborhood.getName(),
+                getNeighborhoodConvenienceTypeCountDto(neighborhoodId, ConvenienceType.MART),
+                getNeighborhoodConvenienceTypeCountDto(neighborhoodId, ConvenienceType.CONVENIENCE_STORE),
+                getNeighborhoodConvenienceTypeCountDto(neighborhoodId, ConvenienceType.HOSPITAL),
+                getNeighborhoodConvenienceTypeCountDto(neighborhoodId, ConvenienceType.CAFE)
+        );
+    }
+
+    /** ConvenienceType별 NeighborhoodConvenience 개수 및 NeighborhoodConvenience 반환 */
+    private ConvenienceTypeCountDto.ConvenienceGroupDto getNeighborhoodConvenienceTypeCountDto(Long neighborhoodId, ConvenienceType convenienceType) {
+        List<ConvenienceTypeCountDto.ConvenienceDto> list = neighborhoodConvenienceRepository.findByNeighborhood_IdAndType(neighborhoodId, convenienceType)
+                .stream()
+                .map(neighborhoodConvenience ->
+                        new ConvenienceTypeCountDto.ConvenienceDto(
+                                neighborhoodConvenience.getName(),
+                                neighborhoodConvenience.getLatitude(),
+                                neighborhoodConvenience.getLongitude()
+                        )
+                ).toList();
+
+        return new ConvenienceTypeCountDto.ConvenienceGroupDto(
+                list.size(),
+                list
+        );
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/service/ConvenienceService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConvenienceService.java
@@ -1,0 +1,41 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
+import me.rentsignal.locationInfo.dto.NeighborhoodConvenienceQueryDto;
+import me.rentsignal.locationInfo.repository.NeighborhoodConvenienceRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConvenienceService {
+
+    private final NeighborhoodConvenienceRepository neighborhoodConvenienceRepository;
+
+    public ConvenienceRankDto getConvenienceRanking() {
+        List<NeighborhoodConvenienceQueryDto> topNeighborhoodConvenienceCount = neighborhoodConvenienceRepository.findTopNeighborhoodConvenienceCount(PageRequest.of(0, 7));
+
+        List<ConvenienceRankDto.NeighborhoodConvenienceCountDto> ranking = new ArrayList<>();
+        int i = 1;
+        for (NeighborhoodConvenienceQueryDto dto : topNeighborhoodConvenienceCount) {
+            Long neighborhoodId = dto.id();
+            String name = dto.name();
+            Long count = dto.count();
+
+            ranking.add(new ConvenienceRankDto.NeighborhoodConvenienceCountDto(
+                    i,
+                    neighborhoodId,
+                    name,
+                    count
+            ));
+            i++;
+        }
+
+        return new ConvenienceRankDto(ranking);
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -5,7 +5,7 @@ import me.rentsignal.global.exception.BaseException;
 import me.rentsignal.global.exception.ErrorCode;
 import me.rentsignal.locationInfo.dto.CurrentRentIndexDto;
 import me.rentsignal.locationInfo.dto.RentIndexChangeDto;
-import me.rentsignal.locationInfo.dto.IndexItemDto;
+import me.rentsignal.locationInfo.dto.RankItemDto;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import me.rentsignal.locationInfo.repository.RegionIndexRepository;
@@ -37,10 +37,10 @@ public class RentIndexService {
 
         List<RegionIndex> indexes = regionIndexRepository.findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(housingType, now.format(formatter));
 
-        List<IndexItemDto> list = new ArrayList<>();
+        List<RankItemDto> list = new ArrayList<>();
         int i = 1;
         for (RegionIndex index : indexes) {
-            list.add(new IndexItemDto(
+            list.add(new RankItemDto(
 
                     i,
                     getRegionName(index),
@@ -68,8 +68,8 @@ public class RentIndexService {
                         index -> index.getRegion().getId(),
                         index -> index));
 
-        List<IndexItemDto> riseList = new ArrayList<>();
-        List<IndexItemDto> fallList = new ArrayList<>();
+        List<RankItemDto> riseList = new ArrayList<>();
+        List<RankItemDto> fallList = new ArrayList<>();
         for (RegionIndex baseIndex : baseIndexes) {
             // comparisonIndexes에 해당 id의 region의 regionIndex가 존재하는지 확인
             RegionIndex comparisonIndex = comparisonIndexMap.get(baseIndex.getRegion().getId());
@@ -86,26 +86,26 @@ public class RentIndexService {
 
             // 증감률이 양수이면 riseList에, 음수이면 fallList에, 0이면 제외
             if (changeRate.compareTo(BigDecimal.ZERO) > 0) {
-                riseList.add(new IndexItemDto(
+                riseList.add(new RankItemDto(
                         0,   // 순위는 임시로 0
                         getRegionName(baseIndex),
                         changeRate));
             } else if (changeRate.compareTo(BigDecimal.ZERO) < 0) {
-                fallList.add(new IndexItemDto(
+                fallList.add(new RankItemDto(
                         0,
                         getRegionName(baseIndex),
                         changeRate));
             }
         }
 
-        List<IndexItemDto> sortedRiseList = riseList.stream()
+        List<RankItemDto> sortedRiseList = riseList.stream()
                 .sorted(
-                        Comparator.comparing(IndexItemDto::value)
+                        Comparator.comparing(RankItemDto::value)
                                 .reversed()).toList();
-        List<IndexItemDto> sortedFallList = fallList.stream()
+        List<RankItemDto> sortedFallList = fallList.stream()
                 .sorted(
                         Comparator.comparing(
-                                IndexItemDto::value)
+                                RankItemDto::value)
                 ).toList();
 
         return new RentIndexChangeDto(
@@ -119,13 +119,13 @@ public class RentIndexService {
     }
 
     /** 정렬된 RentIndexItemDto 리스트 각 요소에 rank 반영해서 새로운 리스트 반환 */
-    private List<IndexItemDto> getRankedList(List<IndexItemDto> sortedList) {
-        List<IndexItemDto> rankedList = new ArrayList<>();
+    private List<RankItemDto> getRankedList(List<RankItemDto> sortedList) {
+        List<RankItemDto> rankedList = new ArrayList<>();
 
         for (int i = 0; i < sortedList.size(); i++) {
-            IndexItemDto item = sortedList.get(i);
+            RankItemDto item = sortedList.get(i);
 
-            rankedList.add(new IndexItemDto(
+            rankedList.add(new RankItemDto(
                     i+1,
                     item.name(),
                     item.value()

--- a/src/main/java/me/rentsignal/locationInfo/service/SafetyService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SafetyService.java
@@ -1,0 +1,54 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.locationInfo.dto.DistrictSafetyDto;
+import me.rentsignal.locationInfo.dto.RankItemDto;
+import me.rentsignal.locationInfo.entity.DistrictSafety;
+import me.rentsignal.locationInfo.repository.DistrictSafetyRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SafetyService {
+
+    private final DistrictSafetyRepository districtSafetyRepository;
+
+    public DistrictSafetyDto getSafety() {
+        List<DistrictSafety> districtSafetyList = districtSafetyRepository.findByDistrict_Province_NameOrderBySafetyScoreDesc("서울특별시");
+
+        List<DistrictSafetyDto.DistrictSafetyScoreDto> districtSafetyScores = new ArrayList<>();
+        List<RankItemDto> ranking = new ArrayList<>();
+        int i = 1;
+
+        for (DistrictSafety districtSafety : districtSafetyList) {
+            String districtName = districtSafety.getDistrict().getName();
+            BigDecimal safetyScore = BigDecimal.valueOf(districtSafety.getSafetyScore()).multiply(BigDecimal.valueOf(100)).setScale(1, RoundingMode.HALF_UP);
+
+            districtSafetyScores.add(new DistrictSafetyDto.DistrictSafetyScoreDto(
+                    districtName,
+                    safetyScore
+            ));
+
+            if (i < 8) {
+                ranking.add(new RankItemDto(
+                        i,
+                        districtName,
+                        safetyScore
+                ));
+            }
+
+            i++;
+        }
+
+        return new DistrictSafetyDto(
+                ranking,
+                districtSafetyScores
+        );
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
@@ -6,7 +6,7 @@ import me.rentsignal.global.exception.ErrorCode;
 import me.rentsignal.location.entity.District;
 import me.rentsignal.location.repository.DistrictRepository;
 import me.rentsignal.locationInfo.dto.DistrictSubwayDto;
-import me.rentsignal.locationInfo.dto.IndexItemDto;
+import me.rentsignal.locationInfo.dto.RankItemDto;
 import me.rentsignal.locationInfo.dto.SubwayAccessibilityIndexDto;
 import me.rentsignal.locationInfo.entity.DistrictIndex;
 import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
@@ -55,8 +55,8 @@ public class SubwayAccessibilityIndexService {
                 ));
 
         List<SubwayAccessibilityIndexDto.DistrictIndexDto> indexes = new ArrayList<>();
-        List<IndexItemDto> high = new ArrayList<>();
-        List<IndexItemDto> changeRate = new ArrayList<>();
+        List<RankItemDto> high = new ArrayList<>();
+        List<RankItemDto> changeRate = new ArrayList<>();
         int i = 1;
         for (DistrictIndex districtIndex : currentIndexes) {
             Long districtId = districtIndex.getDistrict().getId();
@@ -68,11 +68,13 @@ public class SubwayAccessibilityIndexService {
                     districtIndex.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP)
             ));
             // 당월 지하철 역세권 지수 내림차순
-            high.add(new IndexItemDto(
-                    i,
-                    districtName,
-                    districtIndex.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP)
-            ));
+            if (i < 8) {
+                high.add(new RankItemDto(
+                        i,
+                        districtName,
+                        districtIndex.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP)
+                ));
+            }
             i++;
             // 6개월 전 기준 지수 증감률 내림차순
             DistrictIndex previousIndex = previousIndexMap.get(districtId);
@@ -82,18 +84,18 @@ public class SubwayAccessibilityIndexService {
 
             BigDecimal rate = locationInfoService.calculateChangeRate(districtIndex.getSubwayAccessibilityIndex(),
                     previousIndex.getSubwayAccessibilityIndex());
-            changeRate.add(new IndexItemDto(0,
+            changeRate.add(new RankItemDto(0,
                     districtName,
                     rate));
         }
 
         changeRate.sort((a, b) -> b.value().compareTo(a.value()));
 
-        List<IndexItemDto> rankedChangeRate = new ArrayList<>();
-        for (int j = 0; j < changeRate.size(); j++) {
-            IndexItemDto item = changeRate.get(j);
+        List<RankItemDto> rankedChangeRate = new ArrayList<>();
+        for (int j = 0; j < Math.min(7, changeRate.size()); j++) {
+            RankItemDto item = changeRate.get(j);
 
-            rankedChangeRate.add(new IndexItemDto(
+            rankedChangeRate.add(new RankItemDto(
                     j + 1,
                     item.name(),
                     item.value()


### PR DESCRIPTION
## ✅ 관련 이슈
#48 

## ✨ 작업 내용
- 편의시설 순위 조회
편의시설 개수 내림차순 상위 7개 리스트 반환
- 특정 동의 편의시설 조회
경로변수로 전달한 id를 가진 neighborhood의 편의시설의 타입별 개수와 편의시설 위도경도 리스트 반환
- 치안 조회
구별 치안점수 리스트와 치안 점수 내림차순 상위 7개 리스트

## 📸 스크린샷


## 🗨️ 참고 사항
