### PR TITLE
[Feat] 정보탭 교통 부분 데이터 조회 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 **/src/main/resources/convenience.csv
 **/src/main/resources/cctv.csv
 **/src/main/resources/crime.csv
+**/src/main/resources/subway-travel-time.csv
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/src/main/java/me/rentsignal/data/controller/LifeStyleFactorDataCollector.java
+++ b/src/main/java/me/rentsignal/data/controller/LifeStyleFactorDataCollector.java
@@ -20,6 +20,7 @@ public class LifeStyleFactorDataCollector {
     private final SubwayDataService subwayDataService;
     private final ConvenienceDataService convenienceDataService;
     private final SafetyDataService safetyDataService;
+    private final SubwayTravelTimeDataImportService subwayTravelTimeDataImportService;
 
     @PostMapping("/convenience-store")
     public ResponseEntity<?> saveConvenienceStore() {
@@ -60,6 +61,12 @@ public class LifeStyleFactorDataCollector {
     @PostMapping("/safety")
     public ResponseEntity<?> saveSafety() {
         safetyDataService.saveSafety();
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+    @PostMapping("/subway/travel-time")
+    public ResponseEntity<?> saveSubwayTravelTime() {
+        subwayTravelTimeDataImportService.saveSubwayTravelTime();
         return ResponseEntity.ok().body(BaseResponse.success(null));
     }
 

--- a/src/main/java/me/rentsignal/data/dto/SubwayTravelTimeCsvRowDto.java
+++ b/src/main/java/me/rentsignal/data/dto/SubwayTravelTimeCsvRowDto.java
@@ -1,0 +1,16 @@
+package me.rentsignal.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SubwayTravelTimeCsvRowDto {
+
+    private String lineName;
+
+    private String stationName;
+
+    private Integer travelTimeSeconds;
+
+}

--- a/src/main/java/me/rentsignal/data/reader/SubwayTravelTimeCsvReader.java
+++ b/src/main/java/me/rentsignal/data/reader/SubwayTravelTimeCsvReader.java
@@ -1,0 +1,68 @@
+package me.rentsignal.data.reader;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
+import lombok.extern.slf4j.Slf4j;
+import me.rentsignal.data.dto.SubwayTravelTimeCsvRowDto;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+public class SubwayTravelTimeCsvReader {
+
+    /** csv 파일의 행 -> SubwayTravelTimeCsvRowDto 변환 */
+    public List<SubwayTravelTimeCsvRowDto> read() {
+        List<SubwayTravelTimeCsvRowDto> rows = new ArrayList<>();
+
+        try (
+                InputStreamReader isr = new InputStreamReader(
+                        new ClassPathResource("subway-travel-time.csv").getInputStream(), StandardCharsets.UTF_8
+                );
+
+                CSVReader reader = new CSVReader(isr)
+        ){
+            String[] lines;
+            boolean isFirst = true;
+
+            while ((lines = reader.readNext()) != null) {
+                // csv 파일 맨 윗줄 헤더 스킵
+                if (isFirst) {
+                    isFirst = false;
+                    continue;
+                }
+
+                String lineName = lines[0];
+                String stationName = lines[1];
+                String travelTimeSecondsText = lines[2];
+
+                if (travelTimeSecondsText.isBlank()) {
+                    log.warn("역간 소요시간 누락 - lineName={} stationName={}, travelTimeSeconds={}", lineName, stationName, travelTimeSecondsText);
+                    continue;
+                }
+
+                int travelTimeSeconds = Integer.parseInt(travelTimeSecondsText);
+
+                rows.add(
+                        SubwayTravelTimeCsvRowDto.builder()
+                                .lineName(lineName)
+                                .stationName(stationName)
+                                .travelTimeSeconds(travelTimeSeconds).build());
+            }
+        } catch (IOException | CsvValidationException e) {
+            log.error("데이터 로드 실패" + e.getMessage());
+            throw new BaseException(ErrorCode.CSV_READ_ERROR, "지하철 역간 소요시간 데이터 csv 파일 읽기에 실패했습니다. - " + e.getMessage());
+        }
+
+        return rows;
+    }
+
+}

--- a/src/main/java/me/rentsignal/data/service/SubwayTravelTimeDataImportService.java
+++ b/src/main/java/me/rentsignal/data/service/SubwayTravelTimeDataImportService.java
@@ -1,0 +1,91 @@
+package me.rentsignal.data.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.data.dto.SubwayTravelTimeCsvRowDto;
+import me.rentsignal.data.reader.SubwayTravelTimeCsvReader;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
+import me.rentsignal.locationInfo.entity.SubwayTravelTime;
+import me.rentsignal.locationInfo.entity.TransportType;
+import me.rentsignal.locationInfo.repository.NeighborhoodTransportRepository;
+import me.rentsignal.locationInfo.repository.SubwayTravelTimeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SubwayTravelTimeDataImportService {
+
+    private final SubwayTravelTimeCsvReader subwayTravelTimeCsvReader;
+    private final NeighborhoodTransportRepository neighborhoodTransportRepository;
+    private final SubwayTravelTimeRepository subwayTravelTimeRepository;
+
+    @Transactional
+    public void saveSubwayTravelTime() {
+        List<SubwayTravelTimeCsvRowDto> rows = subwayTravelTimeCsvReader.read();
+
+        Map<String, NeighborhoodTransport> neighborhoodTransportMap = loadNeighborhoodTransportMap();
+
+        for (int i = 0; i < rows.size() - 1; i++) {
+            SubwayTravelTimeCsvRowDto row = rows.get(i);
+            SubwayTravelTimeCsvRowDto nextRow = rows.get(i + 1);
+
+            String lineName = convertLineName(row);
+            String transportName = row.getStationName() + "|" + lineName;
+
+            String nextRowLineName = convertLineName(nextRow);
+            String nextRowTransportName = nextRow.getStationName() + "|" + nextRowLineName;
+
+            if (!lineName.equals(nextRowLineName)
+                    && !lineName.equals("별내선") && !nextRowLineName.equals("8호선")
+                    && !lineName.equals("1호선") && !nextRowLineName.equals("중앙선")) {
+                // 환승 고려하지 않기 때문에 노선이 다르면 저장 X
+                // 별내선 - 8호선 또는 1호선 - 중앙선일 경우만 저장
+                continue;
+            }
+
+            NeighborhoodTransport transport = neighborhoodTransportMap.get(transportName);
+            NeighborhoodTransport nextTransport = neighborhoodTransportMap.get(nextRowTransportName);
+
+            if (transport == null || nextTransport == null) {
+                String name = (transport == null) ? transportName : nextRowTransportName;
+                throw new BaseException(ErrorCode.NEIGHBORHOOD_TRANSPORT_NOT_FOUND, "해당 neighborhood transport를 찾을 수 없습니다. - " + name);
+            }
+
+            NeighborhoodTransport fromTransport = transport;
+            NeighborhoodTransport toTransport = nextTransport;
+
+            // 중복되지 않도록 fromTransport에 더 작은 id를 가진 NeighborhoodTransport 지정
+            if (fromTransport.getId() > toTransport.getId()) {
+                fromTransport = nextTransport;
+                toTransport = transport;
+            }
+
+            subwayTravelTimeRepository.save(
+                    SubwayTravelTime.builder()
+                            .lineName(lineName)
+                            .fromStation(fromTransport)
+                            .toStation(toTransport)
+                            .travelTime(nextRow.getTravelTimeSeconds()).build());
+        }
+    }
+
+    /** DB에 저장된 노선 이름으로 변환 */
+    private String convertLineName(SubwayTravelTimeCsvRowDto row) {
+        String rawLineName = row.getLineName();
+        return rawLineName.matches("\\d+") // 숫자로만 이루어진 경우
+                ?  rawLineName + "호선"
+                : rawLineName + "선";
+    }
+
+    private Map<String, NeighborhoodTransport> loadNeighborhoodTransportMap() {
+        return neighborhoodTransportRepository.findAllByTransportType(TransportType.SUBWAY_STATION).stream()
+                .collect(Collectors.toMap(NeighborhoodTransport::getName, n -> n));
+    }
+
+}

--- a/src/main/java/me/rentsignal/global/exception/ErrorCode.java
+++ b/src/main/java/me/rentsignal/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     NEIGHBORHOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 읍/면/동을 찾을 수 없습니다."),
     RI_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리를 찾을 수 없습니다."),
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 권역을 찾을 수 없습니다."),
+    NEIGHBORHOOD_TRANSPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 neighborhood transport를 찾을 수 없습니다."),
 
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
@@ -2,16 +2,18 @@ package me.rentsignal.locationInfo.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.response.BaseResponse;
+import me.rentsignal.locationInfo.dto.RecommendedNeighborhoodByBusinessDistrict;
 import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
 import me.rentsignal.locationInfo.dto.ConvenienceTypeCountDto;
 import me.rentsignal.locationInfo.dto.DistrictSafetyDto;
 import me.rentsignal.locationInfo.service.ConvenienceService;
 import me.rentsignal.locationInfo.service.SafetyService;
+import me.rentsignal.locationInfo.service.TransportService;
+import me.rentsignal.locationInfo.type.BusinessDistrictType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +22,7 @@ public class LocationLivingFactorController {
 
     private final ConvenienceService convenienceService;
     private final SafetyService safetyService;
+    private final TransportService transportService;
 
     @GetMapping("/convenience")
     public ResponseEntity<?> getConvenienceRanking() {
@@ -37,6 +40,12 @@ public class LocationLivingFactorController {
     public ResponseEntity<?> getSafety() {
         DistrictSafetyDto safety = safetyService.getSafety();
         return ResponseEntity.ok().body(BaseResponse.success(safety));
+    }
+
+    @GetMapping("/transport")
+    public ResponseEntity<?> getTransport(@RequestParam BusinessDistrictType type) {
+        List<RecommendedNeighborhoodByBusinessDistrict> recommendedNeighborhoodByBusinessDistrict = transportService.getRecommendedNeighborhoodByBusinessDistrict(type);
+        return ResponseEntity.ok().body(BaseResponse.success(recommendedNeighborhoodByBusinessDistrict));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
@@ -2,10 +2,7 @@ package me.rentsignal.locationInfo.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.response.BaseResponse;
-import me.rentsignal.locationInfo.dto.RecommendedNeighborhoodByBusinessDistrict;
-import me.rentsignal.locationInfo.dto.ConvenienceRankDto;
-import me.rentsignal.locationInfo.dto.ConvenienceTypeCountDto;
-import me.rentsignal.locationInfo.dto.DistrictSafetyDto;
+import me.rentsignal.locationInfo.dto.*;
 import me.rentsignal.locationInfo.service.ConvenienceService;
 import me.rentsignal.locationInfo.service.SafetyService;
 import me.rentsignal.locationInfo.service.TransportService;
@@ -46,6 +43,12 @@ public class LocationLivingFactorController {
     public ResponseEntity<?> getTransport(@RequestParam BusinessDistrictType type) {
         List<RecommendedNeighborhoodByBusinessDistrict> recommendedNeighborhoodByBusinessDistrict = transportService.getRecommendedNeighborhoodByBusinessDistrict(type);
         return ResponseEntity.ok().body(BaseResponse.success(recommendedNeighborhoodByBusinessDistrict));
+    }
+
+    @GetMapping("/transport/{neighborhoodId}")
+    public ResponseEntity<?> getNeighborhoodTransport(@PathVariable Long neighborhoodId) {
+        NeighborhoodTransportDto neighborhoodTransport = transportService.getNeighborhoodTransport(neighborhoodId);
+        return ResponseEntity.ok().body(BaseResponse.success(neighborhoodTransport));
     }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/DistrictSubwayDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/DistrictSubwayDto.java
@@ -8,10 +8,4 @@ public record DistrictSubwayDto(
         BigDecimal value,
         List<SubwayStationDto> subwayStations
 ) {
-
-    public record SubwayStationDto(
-            String lineName,
-            String stationName
-    ) {}
-
 }

--- a/src/main/java/me/rentsignal/locationInfo/dto/NeighborhoodTransportDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/NeighborhoodTransportDto.java
@@ -1,0 +1,17 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.util.List;
+
+public record NeighborhoodTransportDto(
+        String name,
+        List<SubwayStationDto> subwayStations,
+        List<TransportCountDto> counts
+) {
+
+    public record TransportCountDto(
+            String transportType,
+            int count,
+            int ratioToAverage
+    ) {}
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/RecommendedNeighborhoodByBusinessDistrict.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/RecommendedNeighborhoodByBusinessDistrict.java
@@ -1,0 +1,10 @@
+package me.rentsignal.locationInfo.dto;
+
+import java.util.List;
+
+public record RecommendedNeighborhoodByBusinessDistrict(
+        Long id,
+        String name,
+        List<SubwayReachableStationDto> stations
+) {
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/SubwayReachableStationDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/SubwayReachableStationDto.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.dto;
+
+public record SubwayReachableStationDto(
+        String lineName,
+        String stationName,
+        int travelTimeMinutes,
+        int travelTimeSeconds
+) {
+}

--- a/src/main/java/me/rentsignal/locationInfo/dto/SubwayStationDto.java
+++ b/src/main/java/me/rentsignal/locationInfo/dto/SubwayStationDto.java
@@ -1,0 +1,6 @@
+package me.rentsignal.locationInfo.dto;
+
+public record SubwayStationDto(
+        String lineName,
+        String stationName
+) {}

--- a/src/main/java/me/rentsignal/locationInfo/entity/SubwayTravelTime.java
+++ b/src/main/java/me/rentsignal/locationInfo/entity/SubwayTravelTime.java
@@ -1,0 +1,48 @@
+package me.rentsignal.locationInfo.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 지하철 역간 소요시간
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"line_name", "from_station_id", "to_station_id"})
+        }
+)
+public class SubwayTravelTime {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String lineName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_station_id")
+    private NeighborhoodTransport fromStation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_station_id")
+    private NeighborhoodTransport toStation;
+
+    @Column(nullable = false)
+    private int travelTimeSeconds;
+
+    @Builder
+    public SubwayTravelTime(String lineName, NeighborhoodTransport fromStation, NeighborhoodTransport toStation, int travelTime) {
+        this.lineName = lineName;
+        this.fromStation = fromStation;
+        this.toStation = toStation;
+        this.travelTimeSeconds = travelTime;
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
@@ -14,4 +14,6 @@ public interface NeighborhoodTransportRepository extends JpaRepository<Neighborh
     List<NeighborhoodTransport> findByNeighborhood_District_IdAndTransportType(Long id, TransportType type);
     List<NeighborhoodTransport> findAllByTransportType(TransportType type);
     Optional<NeighborhoodTransport> findByNameAndTransportType(String name, TransportType type);
+    List<NeighborhoodTransport> findByNeighborhood_IdAndTransportType(Long id, TransportType type);
+    int countByNeighborhood_IdAndTransportType(Long id, TransportType type);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Repository
 public interface NeighborhoodTransportRepository extends JpaRepository<NeighborhoodTransport, Long> {
     List<NeighborhoodTransport> findByNeighborhood_District_IdAndTransportType(Long id, TransportType type);
     List<NeighborhoodTransport> findAllByTransportType(TransportType type);
+    Optional<NeighborhoodTransport> findByNameAndTransportType(String name, TransportType type);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/NeighborhoodTransportRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 @Repository
 public interface NeighborhoodTransportRepository extends JpaRepository<NeighborhoodTransport, Long> {
     List<NeighborhoodTransport> findByNeighborhood_District_IdAndTransportType(Long id, TransportType type);
+    List<NeighborhoodTransport> findAllByTransportType(TransportType type);
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/SubwayTravelTimeRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/SubwayTravelTimeRepository.java
@@ -1,0 +1,9 @@
+package me.rentsignal.locationInfo.repository;
+
+import me.rentsignal.locationInfo.entity.SubwayTravelTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubwayTravelTimeRepository extends JpaRepository<SubwayTravelTime, Long> {
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
@@ -8,6 +8,7 @@ import me.rentsignal.location.repository.DistrictRepository;
 import me.rentsignal.locationInfo.dto.DistrictSubwayDto;
 import me.rentsignal.locationInfo.dto.RankItemDto;
 import me.rentsignal.locationInfo.dto.SubwayAccessibilityIndexDto;
+import me.rentsignal.locationInfo.dto.SubwayStationDto;
 import me.rentsignal.locationInfo.entity.DistrictIndex;
 import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
 import me.rentsignal.locationInfo.entity.TransportType;
@@ -114,13 +115,13 @@ public class SubwayAccessibilityIndexService {
                 () -> new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 id의 시/군/구가 존재하지 않습니다."));
 
         List<NeighborhoodTransport> neighborhoodTransports = neighborhoodTransportRepository.findByNeighborhood_District_IdAndTransportType(districtId, TransportType.SUBWAY_STATION);
-        List<DistrictSubwayDto.SubwayStationDto> subwayStations = new ArrayList<>();
+        List<SubwayStationDto> subwayStations = new ArrayList<>();
         for (NeighborhoodTransport transport : neighborhoodTransports) {
             String name = transport.getName();
             String[] arr = name.split("\\|");
             String stationName = arr[0];
             String lineName = arr[1];
-            subwayStations.add(new DistrictSubwayDto.SubwayStationDto(
+            subwayStations.add(new SubwayStationDto(
                     lineName,
                     stationName
             ));

--- a/src/main/java/me/rentsignal/locationInfo/service/TransportService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/TransportService.java
@@ -1,0 +1,218 @@
+package me.rentsignal.locationInfo.service;
+
+import lombok.RequiredArgsConstructor;
+import me.rentsignal.global.exception.BaseException;
+import me.rentsignal.global.exception.ErrorCode;
+import me.rentsignal.location.entity.Neighborhood;
+import me.rentsignal.locationInfo.dto.RecommendedNeighborhoodByBusinessDistrict;
+import me.rentsignal.locationInfo.dto.SubwayReachableStationDto;
+import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
+import me.rentsignal.locationInfo.entity.SubwayTravelTime;
+import me.rentsignal.locationInfo.entity.TransportType;
+import me.rentsignal.locationInfo.repository.NeighborhoodTransportRepository;
+import me.rentsignal.locationInfo.repository.SubwayTravelTimeRepository;
+import me.rentsignal.locationInfo.type.BusinessDistrictType;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class TransportService {
+
+    private static final int MAX_SECONDS = 20 * 60; // 20분
+
+    private final NeighborhoodTransportRepository neighborhoodTransportRepository;
+    private final SubwayTravelTimeRepository subwayTravelTimeRepository;
+
+    /** 환승 제외 주요 업무지구까지 20분 이내 소요되는 지하철역 조회 */
+    public List<RecommendedNeighborhoodByBusinessDistrict> getRecommendedNeighborhoodByBusinessDistrict(BusinessDistrictType businessDistrictType) {
+        String neighborhoodTransportName = convertToNeighborhoodTransportName(businessDistrictType);
+        String[] names = neighborhoodTransportName.split(",");
+
+        Map<Long, NeighborhoodStationGroup> grouped = new HashMap<>();
+
+        for (String name : names) {
+            NeighborhoodTransport mainStation = neighborhoodTransportRepository.findByNameAndTransportType(name, TransportType.SUBWAY_STATION).orElseThrow(
+                    () -> new BaseException(ErrorCode.NEIGHBORHOOD_TRANSPORT_NOT_FOUND, "해당 이름의 neighborhoodTransport가 존재하지 않습니다. - " + name));
+
+            // 기준역까지 maxSeconds (20분) 내 도달 가능한 지하철역 찾기
+            List<ReachableStationAndNeighborhood> reachableStationAndNeighborhoods = findReachableStations(mainStation.getId(), MAX_SECONDS);
+
+            // neighborhood별로 그룹핑
+            for (ReachableStationAndNeighborhood reachableStationAndNeighborhood : reachableStationAndNeighborhoods) {
+                Neighborhood neighborhood = reachableStationAndNeighborhood.neighborhood();
+
+                String[] arr = reachableStationAndNeighborhood.stationName().split("\\|");
+                NeighborhoodStationGroup group = grouped.computeIfAbsent(
+                        neighborhood.getId(),
+                        key -> new NeighborhoodStationGroup(neighborhood)
+                );
+
+                group.stations().add(
+                        new SubwayReachableStationDto(
+                                arr[1],
+                                arr[0],
+                                reachableStationAndNeighborhood.seconds() / 60,
+                                reachableStationAndNeighborhood.seconds() % 60
+                        )
+                );
+            }
+        }
+
+        return grouped.values().stream()
+                .map(group -> new RecommendedNeighborhoodByBusinessDistrict(
+                        group.neighborhood().getId(),
+                        group.neighborhood().getDistrict().getName().replace("시", "시 ") + " " + group.neighborhood().getName(),
+                        group.stations()
+                )).toList();
+    }
+
+    private String convertToNeighborhoodTransportName(BusinessDistrictType businessDistrictType) {
+        return switch (businessDistrictType) {
+            case GBD_GANGNAM -> "강남|2호선,강남|신분당선";
+            case GBD_YEOKSAM -> "역삼|2호선";
+            case GBD_JAMSIL -> "잠실(송파구청)|2호선,잠실(송파구청)|8호선";
+            case GBD_SAMSEONG -> "삼성(무역센터)|2호선";
+            case YBD_YEOUIDO -> "여의도|5호선,여의도|9호선";
+            case YBD_YEOUINARU -> "여의나루|5호선";
+            case YBD_DANGSAN -> "당산|2호선,당산|9호선";
+            case CBD_GWANGHWAMUN -> "광화문(세종문화회관)|5호선";
+            case CBD_CITYHALL -> "시청|1호선,시청|2호선";
+            case CBD_JONGGAK -> "종각|1호선";
+        };
+    }
+
+    private List<ReachableStationAndNeighborhood> findReachableStations(Long fromId, int maxSeconds) {
+        List<SubwayTravelTime> all = subwayTravelTimeRepository.findAll();
+
+        Map<Long, List<Edge>> graph = buildGraph(all);
+
+        Map<Long, NeighborhoodTransport> neighborhoodTransportMap = loadNeighborhoodTransportMap(all);
+
+        Map<Long, Integer> distances = dijkstra(fromId, graph, maxSeconds);
+
+        return distances.entrySet().stream()
+                .filter(entry -> entry.getValue() <= maxSeconds)
+                .filter(entry -> !entry.getKey().equals(fromId))
+                .map(entry -> {
+                    NeighborhoodTransport subwayStation = neighborhoodTransportMap.get(entry.getKey());
+
+                    if (subwayStation == null || subwayStation.getNeighborhood() == null) {
+                        return null;
+                    }
+
+                    return new ReachableStationAndNeighborhood(
+                            subwayStation.getName(),
+                            subwayStation.getNeighborhood(),
+                            entry.getValue()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /** 지하철역 노드로 이루어진 그래프 생성 */
+    private Map<Long, List<Edge>> buildGraph(List<SubwayTravelTime> subwayTravelTimes) {
+        Map<Long, List<Edge>> graph = new HashMap<>();
+
+        for (SubwayTravelTime subwayTravelTime : subwayTravelTimes) {
+            // 역 ID -> 해당 역에서 갈 수 있는 역 리스트
+            Long fromId = subwayTravelTime.getFromStation().getId();
+            Long toId = subwayTravelTime.getToStation().getId();
+            int seconds = subwayTravelTime.getTravelTimeSeconds();
+
+            // 양방향 그래프
+            graph.computeIfAbsent(fromId, key -> new ArrayList<>())
+                    .add(new Edge(toId, seconds));
+            graph.computeIfAbsent(toId, key -> new ArrayList<>())
+                    .add(new Edge(fromId, seconds));
+        }
+
+        return graph;
+    }
+
+    /** 다익스트라로 maxSeconds (20분) 이내 최단경로 계산 */
+    private Map<Long, Integer> dijkstra(Long fromId, Map<Long, List<Edge>> graph, int maxSeconds) {
+        // 각 역별로 기준 역에서 걸리는 최소시간
+        Map<Long, Integer> distances = new HashMap<>();
+        // 현재까지 발견한 역 중 이동시간이 가장 짧은 역 꺼냄
+        PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparingInt(Node::seconds));
+
+        distances.put(fromId, 0);
+        pq.add(new Node(fromId, 0));
+
+        while (!pq.isEmpty()) {
+            // 1. 현재 가장 가까운 역
+            Node current = pq.poll();
+
+            // 2. 방금 PQ에서 꺼낸 후보 경로의 시간 > 실제 최단 시간이거나 최대 시간 오버할 경우 무시
+            if (current.seconds() > distances.getOrDefault(current.stationId(), Integer.MAX_VALUE)
+                    || current.seconds() > maxSeconds) {
+                continue;
+            }
+
+            // 3. 현재 역과 연결된 인접역 확인
+            for (Edge edge : graph.getOrDefault(current.stationId(), List.of())) {
+                // 다음 인접역까지 총 소요시간
+                int nextSeconds = current.seconds() + edge.seconds();
+
+                if (nextSeconds > maxSeconds) {
+                    continue;
+                }
+
+                // 다음 역까지의 기존 경로보다 더 짧을 경우 갱신
+                if (nextSeconds < distances.getOrDefault(edge.toStationId(), Integer.MAX_VALUE)) {
+                    distances.put(edge.toStationId(), nextSeconds);
+                    pq.add(new Node(edge.toStationId(), nextSeconds));
+                }
+            }
+        }
+
+        return distances;
+    }
+
+    private Map<Long, NeighborhoodTransport> loadNeighborhoodTransportMap(List<SubwayTravelTime> subwayTravelTimes) {
+        Map<Long, NeighborhoodTransport> neighborhoodTransportMap = new HashMap<>();
+
+        for (SubwayTravelTime subwayTravelTime : subwayTravelTimes) {
+            neighborhoodTransportMap.put(
+                    subwayTravelTime.getFromStation().getId(),
+                    subwayTravelTime.getFromStation()
+            );
+
+            neighborhoodTransportMap.put(
+                    subwayTravelTime.getToStation().getId(),
+                    subwayTravelTime.getToStation()
+            );
+        }
+
+        return neighborhoodTransportMap;
+    }
+
+    private record NeighborhoodStationGroup(
+            Neighborhood neighborhood,
+            List<SubwayReachableStationDto> stations
+    ) {
+        private NeighborhoodStationGroup(Neighborhood neighborhood) {
+            this(neighborhood, new ArrayList<>());
+        }
+    }
+
+    private record ReachableStationAndNeighborhood(
+            String stationName,
+            Neighborhood neighborhood,
+            int seconds
+    ) {}
+
+    private record Edge(
+            Long toStationId,
+            int seconds
+    ) {}
+
+    private record Node(
+            Long stationId,
+            int seconds
+    ) {}
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/service/TransportService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/TransportService.java
@@ -4,8 +4,11 @@ import lombok.RequiredArgsConstructor;
 import me.rentsignal.global.exception.BaseException;
 import me.rentsignal.global.exception.ErrorCode;
 import me.rentsignal.location.entity.Neighborhood;
+import me.rentsignal.location.repository.NeighborhoodRepository;
+import me.rentsignal.locationInfo.dto.NeighborhoodTransportDto;
 import me.rentsignal.locationInfo.dto.RecommendedNeighborhoodByBusinessDistrict;
 import me.rentsignal.locationInfo.dto.SubwayReachableStationDto;
+import me.rentsignal.locationInfo.dto.SubwayStationDto;
 import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
 import me.rentsignal.locationInfo.entity.SubwayTravelTime;
 import me.rentsignal.locationInfo.entity.TransportType;
@@ -21,9 +24,12 @@ import java.util.*;
 public class TransportService {
 
     private static final int MAX_SECONDS = 20 * 60; // 20분
+    private static final double AVG_SUBWAY_STATION_COUNT = 0.8565;
+    private static final double AVG_BUS_STOP_COUNT = 32.6681;
 
     private final NeighborhoodTransportRepository neighborhoodTransportRepository;
     private final SubwayTravelTimeRepository subwayTravelTimeRepository;
+    private final NeighborhoodRepository neighborhoodRepository;
 
     /** 환승 제외 주요 업무지구까지 20분 이내 소요되는 지하철역 조회 */
     public List<RecommendedNeighborhoodByBusinessDistrict> getRecommendedNeighborhoodByBusinessDistrict(BusinessDistrictType businessDistrictType) {
@@ -214,5 +220,43 @@ public class TransportService {
             Long stationId,
             int seconds
     ) {}
+
+    public NeighborhoodTransportDto getNeighborhoodTransport(Long neighborhoodId) {
+        Neighborhood neighborhood = neighborhoodRepository.findById(neighborhoodId).orElseThrow(
+                () -> new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 id의 읍/면/동이 존재하지 않습니다."));
+
+        List<NeighborhoodTransport> neighborhoodTransports = neighborhoodTransportRepository.findByNeighborhood_IdAndTransportType(neighborhoodId, TransportType.SUBWAY_STATION);
+        List<SubwayStationDto> subwayStations = new ArrayList<>();
+        for (NeighborhoodTransport neighborhoodTransport : neighborhoodTransports) {
+            String[] arr = neighborhoodTransport.getName().split("\\|");
+            subwayStations.add(new SubwayStationDto(
+                    arr[1],
+                    arr[0]
+            ));
+        }
+
+        int subwayStationCount = neighborhoodTransports.size();
+        int busStopCount = neighborhoodTransportRepository.countByNeighborhood_IdAndTransportType(neighborhoodId, TransportType.BUS_STOP);
+
+        int subwayCountRatioToAverage = (int) Math.round((subwayStationCount / AVG_SUBWAY_STATION_COUNT) * 100);
+        int busCountRatioToAverage = (int) Math.round((busStopCount / AVG_BUS_STOP_COUNT) * 100);
+
+        return new NeighborhoodTransportDto(
+                neighborhood.getDistrict().getName().replace("시", "시 ") + " " + neighborhood.getName(),
+                subwayStations,
+                List.of(
+                        new NeighborhoodTransportDto.TransportCountDto(
+                                TransportType.BUS_STOP.name(),
+                                busStopCount,
+                                busCountRatioToAverage
+                        ),
+                        new NeighborhoodTransportDto.TransportCountDto(
+                                TransportType.SUBWAY_STATION.name(),
+                                subwayStationCount,
+                                subwayCountRatioToAverage
+                        )
+                )
+        );
+    }
 
 }

--- a/src/main/java/me/rentsignal/locationInfo/type/BusinessDistrictType.java
+++ b/src/main/java/me/rentsignal/locationInfo/type/BusinessDistrictType.java
@@ -1,0 +1,21 @@
+package me.rentsignal.locationInfo.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BusinessDistrictType {
+    GBD_GANGNAM("강남역"),
+    GBD_YEOKSAM("역삼역"),
+    GBD_SAMSEONG("삼성역"),
+    GBD_JAMSIL("잠실역"),
+    YBD_YEOUIDO("여의도역"),
+    YBD_YEOUINARU("여의나루역"),
+    YBD_DANGSAN("당산역"),
+    CBD_GWANGHWAMUN("광화문역"),
+    CBD_CITYHALL("시청역"),
+    CBD_JONGGAK("종각역");
+
+    public final String name;
+}


### PR DESCRIPTION
## ✅ 관련 이슈
closed #48 

## ✨ 작업 내용
- 지하철 역간 소요시간 저장 구현
- 주요 업무지구 기준 추천 동 조회 구현
환승은 고려하지 않고 같은 노선 내에서 주요 업무지구 내 특정 역까지 20분 내에 갈 수 있는 역 조회
추후 확장과 2호선 순환 노선 처리를 위해 다익스트라로 최단 이동시간 계산
- 특정 동에 위치한 교통수단 개수 및 평균 대비 비율 조회 구현

## 📸 스크린샷


## 🗨️ 참고 사항
신분당선(연장), 신분당선(연장2)라고 되어있던 데이터를 신분당선으로 변경해주기 위해 기존에 지하철 데이터를 저장하셨다면 MySQL 콘솔에서 아래 SQL문을 실행해주세요!
```
UPDATE neighborhood_transport
SET name = REPLACE(name, '(연장)', '')
WHERE name LIKE '%(연장)%';

UPDATE neighborhood_transport
SET name = REPLACE(name, '(연장2)', '')
WHERE name LIKE '%(연장2)%';
```