### PR TITLE
[Refactor] 마이페이지탭 댓글 조회를 게시글 기반으로 변경

### DIFF
--- a/src/main/java/me/rentsignal/community/controller/CommunityController.java
+++ b/src/main/java/me/rentsignal/community/controller/CommunityController.java
@@ -153,7 +153,7 @@ public class CommunityController {
 
     // 내가 쓴 댓글 조회
     @GetMapping("/mypage/comments")
-    public BaseResponse<Page<CommentResponse>> getMyComments(
+    public BaseResponse<Page<PostListItemResponse>> getMyComments(
             @AuthenticationPrincipal CustomPrincipal principal,
             Pageable pageable
     ) {

--- a/src/main/java/me/rentsignal/community/repository/CommentRepository.java
+++ b/src/main/java/me/rentsignal/community/repository/CommentRepository.java
@@ -1,14 +1,26 @@
 package me.rentsignal.community.repository;
 
 import me.rentsignal.community.domain.Comment;
+import me.rentsignal.community.domain.Post;
 import me.rentsignal.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId, Pageable pageable);
+
     Page<Comment> findByUser(User user, Pageable pageable);
 
+    @Query("""
+        select distinct c.post
+        from Comment c
+        where c.user = :user
+          and c.isDeleted = false
+          and c.post.isDeleted = false
+    """)
+    Page<Post> findPostsByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/me/rentsignal/community/service/CommunityService.java
+++ b/src/main/java/me/rentsignal/community/service/CommunityService.java
@@ -285,13 +285,13 @@ public class CommunityService {
 
     // 내가 쓴 댓글
     @Transactional(readOnly = true)
-    public Page<CommentResponse> getMyComments(CustomPrincipal principal, Pageable pageable) {
+    public Page<PostListItemResponse> getMyComments(CustomPrincipal principal, Pageable pageable) {
 
         User user = authService.getCurrentUser(principal.getId());
 
         return commentRepository
-                .findByUser(user, pageable)
-                .map(CommentResponse::from);
+                .findPostsByUser(user, pageable)
+                .map(PostListItemResponse::from);
     }
 
     // 내가 좋아요한 글


### PR DESCRIPTION
## ✅ 관련 이슈
#54 

## ✨ 작업 내용
- 댓글 내용 제거
- 게시글 형식(PostListItemResponse)으로 응답 통일
- 중복 댓글 작성 시 게시글 1회만 반환하도록 수정

## 📸 스크린샷


## 🗨️ 참고 사항
