### PR TITLE
[Feat] 정보탭 데이터 조회 baseYearMonth 수정

### DIFF
--- a/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/DistrictIndexRepository.java
@@ -2,6 +2,7 @@ package me.rentsignal.locationInfo.repository;
 
 import me.rentsignal.locationInfo.entity.DistrictIndex;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +12,9 @@ import java.util.Optional;
 public interface DistrictIndexRepository extends JpaRepository<DistrictIndex, Long> {
     List<DistrictIndex> findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc(String provinceName, String baseYearMonth);
     Optional<DistrictIndex> findByDistrict_IdAndBaseYearMonth(Long districtId, String baseYearMonth);
+    @Query("""
+    SELECT MAX(d.baseYearMonth)
+    FROM DistrictIndex d
+""")
+    String findLatestBaseYearMonth();
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/ProvinceIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/ProvinceIndexRepository.java
@@ -2,6 +2,7 @@ package me.rentsignal.locationInfo.repository;
 
 import me.rentsignal.locationInfo.entity.ProvinceIndex;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +12,9 @@ import java.util.Optional;
 public interface ProvinceIndexRepository extends JpaRepository<ProvinceIndex, Long> {
     Optional<ProvinceIndex> findByProvince_NameAndBaseYearMonth(String name, String baseYearMonth);
     List<ProvinceIndex> findByProvince_NameAndBaseYearMonthBetweenOrderByBaseYearMonthAsc(String name, String start, String end);
+    @Query("""
+    SELECT MAX(p.baseYearMonth)
+    FROM ProvinceIndex p
+""")
+    String findLatestBaseYearMonth();
 }

--- a/src/main/java/me/rentsignal/locationInfo/repository/RegionIndexRepository.java
+++ b/src/main/java/me/rentsignal/locationInfo/repository/RegionIndexRepository.java
@@ -3,6 +3,7 @@ package me.rentsignal.locationInfo.repository;
 import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +12,9 @@ import java.util.List;
 public interface RegionIndexRepository extends JpaRepository<RegionIndex, Long> {
     List<RegionIndex> findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(HousingType housingType, String baseYearMonth);
     List<RegionIndex> findByHousingTypeAndBaseYearMonth(HousingType housingType, String baseYearMonth);
+    @Query("""
+    SELECT MAX(r.baseYearMonth)
+    FROM RegionIndex r
+""")
+    String findLatestBaseYearMonth();
 }

--- a/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
@@ -5,6 +5,7 @@ import me.rentsignal.locationInfo.dto.ConsumerSentimentIndexDto;
 import me.rentsignal.locationInfo.entity.ProvinceIndex;
 import me.rentsignal.locationInfo.repository.ProvinceIndexRepository;
 import me.rentsignal.locationInfo.type.PeriodType;
+import me.rentsignal.locationInfo.util.YearMonthUtils;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -23,17 +24,16 @@ public class ConsumerSentimentIndexService {
 
     // 현재는 서울특별시 데이터만 반환
     public ConsumerSentimentIndexDto getConsumerSentimentIndex(PeriodType periodType) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-
         // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
-        YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
+        String baseYearMonthText = provinceIndexRepository.findLatestBaseYearMonth();
+        YearMonth baseYearMonth = YearMonthUtils.toYearMonth(baseYearMonthText);
         YearMonth yearMonth = periodType.toComparisonYearMonth(baseYearMonth);
 
-        String formattedYearMonth = yearMonth.format(formatter);
-        ProvinceIndex baseIndex = provinceIndexRepository.findByProvince_NameAndBaseYearMonth("서울특별시", baseYearMonth.format(formatter)).orElse(null);
+        ProvinceIndex baseIndex = provinceIndexRepository.findByProvince_NameAndBaseYearMonth("서울특별시", baseYearMonthText).orElse(null);
         BigDecimal baseValue = (baseIndex != null) ? baseIndex.getConsumerSentimentIndex() : BigDecimal.ZERO;
 
         BigDecimal value;
+        String formattedYearMonth = YearMonthUtils.formatYearMonth(yearMonth);
         if (periodType == PeriodType.CURRENT) {
             value = baseValue.setScale(1, RoundingMode.HALF_UP);
         } else {
@@ -55,9 +55,8 @@ public class ConsumerSentimentIndexService {
 
     /** baseYearMonth로부터 6개월 전까지의 데이터 조회 */
     private List<ConsumerSentimentIndexDto.MonthlyConsumerSentimentIndexDto> getConsumerSentimentIndexTrend(YearMonth baseYearMonth) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-        String end = baseYearMonth.format(formatter);
-        String start = baseYearMonth.minusMonths(6).format(formatter);
+        String end = YearMonthUtils.formatYearMonth(baseYearMonth);
+        String start = YearMonthUtils.formatYearMonth(baseYearMonth.minusMonths(6));
 
         List<ProvinceIndex> indexes = provinceIndexRepository.findByProvince_NameAndBaseYearMonthBetweenOrderByBaseYearMonthAsc("서울특별시", start, end);
 

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -10,12 +10,12 @@ import me.rentsignal.locationInfo.entity.HousingType;
 import me.rentsignal.locationInfo.entity.RegionIndex;
 import me.rentsignal.locationInfo.repository.RegionIndexRepository;
 import me.rentsignal.locationInfo.type.PeriodType;
+import me.rentsignal.locationInfo.util.YearMonthUtils;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -29,13 +29,11 @@ public class RentIndexService {
     private final RegionIndexRepository regionIndexRepository;
     private final LocationInfoService locationInfoService;
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-
     public CurrentRentIndexDto getCurrentRentIndex(HousingType housingType) {
         // 데이터가 1개월 지연되어 제공되기 때문에 1개월 전 데이터 사용
-        YearMonth now = YearMonth.now().minusMonths(1);
+        String baseYearMonth = regionIndexRepository.findLatestBaseYearMonth();
 
-        List<RegionIndex> indexes = regionIndexRepository.findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(housingType, now.format(formatter));
+        List<RegionIndex> indexes = regionIndexRepository.findByHousingTypeAndBaseYearMonthOrderByRentCompositeIndexDesc(housingType, baseYearMonth);
 
         List<RankItemDto> list = new ArrayList<>();
         int i = 1;
@@ -53,15 +51,17 @@ public class RentIndexService {
     }
 
     public RentIndexChangeDto getRentIndexChange(HousingType housingType, PeriodType periodType) {
-        YearMonth baseYearMonth = YearMonth.now().minusMonths(1);
+        String baseYearMonthText = regionIndexRepository.findLatestBaseYearMonth();
+        YearMonth baseYearMonth = YearMonthUtils.toYearMonth(baseYearMonthText);
 
         if (periodType == PeriodType.CURRENT) {
             throw new BaseException(ErrorCode.INVALID_INPUT_VALUE, "해당 periodType을 지원하지 않습니다.");
         }
+
         YearMonth comparisonYearMonth = periodType.toComparisonYearMonth(baseYearMonth);
 
-        List<RegionIndex> baseIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, baseYearMonth.format(formatter));
-        List<RegionIndex> comparisonIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, comparisonYearMonth.format(formatter));
+        List<RegionIndex> baseIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, YearMonthUtils.formatYearMonth(baseYearMonth));
+        List<RegionIndex> comparisonIndexes = regionIndexRepository.findByHousingTypeAndBaseYearMonth(housingType, YearMonthUtils.formatYearMonth(comparisonYearMonth));
 
         Map<Long, RegionIndex> comparisonIndexMap = comparisonIndexes.stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
@@ -14,6 +14,7 @@ import me.rentsignal.locationInfo.entity.NeighborhoodTransport;
 import me.rentsignal.locationInfo.entity.TransportType;
 import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
 import me.rentsignal.locationInfo.repository.NeighborhoodTransportRepository;
+import me.rentsignal.locationInfo.util.YearMonthUtils;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -34,15 +35,13 @@ public class SubwayAccessibilityIndexService {
     private final DistrictRepository districtRepository;
     private final NeighborhoodTransportRepository neighborhoodTransportRepository;
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-
     public SubwayAccessibilityIndexDto getSubwayAccessibilityIndex() {
         // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
-        YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
-        YearMonth comparisonYearMonth = baseYearMonth.minusMonths(6);
+        String base = districtIndexRepository.findLatestBaseYearMonth();
+        YearMonth baseYearMonth = YearMonthUtils.toYearMonth(base);
 
-        String base = baseYearMonth.format(formatter);
-        String comparison = comparisonYearMonth.format(formatter);
+        YearMonth comparisonYearMonth = baseYearMonth.minusMonths(6);
+        String comparison = YearMonthUtils.formatYearMonth(comparisonYearMonth);
 
         // 서울특별시 데이터의 당월, 6개월 전 데이터 조회
         List<DistrictIndex> currentIndexes = districtIndexRepository.findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc("서울특별시", base);
@@ -127,8 +126,8 @@ public class SubwayAccessibilityIndexService {
             ));
         }
 
-        YearMonth baseYearMonth = YearMonth.now().minusMonths(2);
-        DistrictIndex index = districtIndexRepository.findByDistrict_IdAndBaseYearMonth(districtId, baseYearMonth.format(formatter)).orElse(null);
+        String baseYearMonth = districtIndexRepository.findLatestBaseYearMonth();
+        DistrictIndex index = districtIndexRepository.findByDistrict_IdAndBaseYearMonth(districtId, baseYearMonth).orElse(null);
         BigDecimal value = (index != null) ? index.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP) : BigDecimal.ZERO;
 
         return new DistrictSubwayDto(

--- a/src/main/java/me/rentsignal/locationInfo/util/YearMonthUtils.java
+++ b/src/main/java/me/rentsignal/locationInfo/util/YearMonthUtils.java
@@ -1,0 +1,20 @@
+package me.rentsignal.locationInfo.util;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+public final class YearMonthUtils {
+
+    private YearMonthUtils() {}
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
+    public static YearMonth toYearMonth(String value) {
+        return YearMonth.parse(value, FORMATTER);
+    }
+
+    public static String formatYearMonth(YearMonth value) {
+        return value.format(FORMATTER);
+    }
+
+}


### PR DESCRIPTION
## ✅ 관련 이슈
closed #56 

## ✨ 작업 내용
### 1. 데이터 조회 기준 YearMonth 변경
- **[기존 방식]** 기존에는 데이터 조회 시 `YearMonth.now.minusMonths(..)`와 같이 데이터 제공 기관의 지연 시간을 고려한 기준 YearMonth를 계산해 사용했습니다.
- **[문제점]** 데이터 API에서는 달이 바뀌더라도 데이터가 즉시 업데이트되지 않기 때문에 달이 바뀐 시점부터 데이터 업데이트되는 시점까지는 기준 YearMonth의 데이터가 조회되지 않는 문제가 발생했습니다.
- **[해결]** 해당 방식 대신 DB에 저장된 데이터 중 가장 최신 baseYearMonth 값을 조회 후 해당 YearMonth를 기준으로 데이터를 조회하도록 수정했습니다.

### 2. YearMonth 공통 유틸 클래스 추가
- **[기존 방식]** 기존에는 클래스별로 DateTimeFormatter를 정의해서 사용하는 방식이었습니다.
- **[개선 이유]** 코드 중복이 존재했고, 1번 변경사항으로 인해 DB에서 조회한 최신 baseYearMonth String 값을 YearMonth로 파싱하는 로직이 필요해졌습니다.
- **[개선]**  별도의 YearMonthUtils 클래스를 정의하여 String -> YearMonth 파싱, YearMonth -> String 포맷팅 메서드를 정의하고 공통으로 DateTimeFormatter를 관리할 수 있도록 함으로써 중복 코드를 줄이고 YearMonth 관련 로직을 한 곳에서 관리할 수 있도록 개선했습니다.

## 📸 스크린샷


## 🗨️ 참고 사항
