### PR TITLE
[Fix] 지하철 역세권 지수 랭킹 최신 월 조회 방식 수정

### DIFF
--- a/src/main/java/me/rentsignal/home/service/HomeService.java
+++ b/src/main/java/me/rentsignal/home/service/HomeService.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.RoundingMode;
-import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,11 +42,7 @@ public class HomeService {
     }
 
     public List<RankItemDto> getSubwayAccessibilityRanking() {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
-
-        String baseYearMonth = YearMonth.now()
-                .minusMonths(2)
-                .format(formatter);
+        String baseYearMonth = districtIndexRepository.findLatestBaseYearMonth();
 
         List<DistrictIndex> indexes = districtIndexRepository
                 .findByDistrict_Province_NameAndBaseYearMonthOrderBySubwayAccessibilityIndexDesc(


### PR DESCRIPTION
## ✅ 관련 이슈
#58 

## ✨ 작업 내용
- YearMonth.now().minusMonths(2) 방식 제거
- DB에 저장된 최신 baseYearMonth 기준으로 조회하도록 수정
- 데이터 적재 시점과 무관하게 최신 데이터 조회 가능하도록 개선

## 📸 스크린샷


## 🗨️ 참고 사항
