### PR TITLE
[Feat] 데이터 조회 시 캐시 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
     // JTS
     implementation 'org.locationtech.jts:jts-core:1.19.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 test {

--- a/src/main/java/me/rentsignal/RentsignalBackendApplication.java
+++ b/src/main/java/me/rentsignal/RentsignalBackendApplication.java
@@ -2,9 +2,11 @@ package me.rentsignal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class RentsignalBackendApplication {
     public static void main(String[] args) {

--- a/src/main/java/me/rentsignal/global/config/RedisConfig.java
+++ b/src/main/java/me/rentsignal/global/config/RedisConfig.java
@@ -1,0 +1,70 @@
+package me.rentsignal.global.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        BasicPolymorphicTypeValidator typeValidator =
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType("me.rentsignal")
+                        .allowIfBaseType("java.util")
+                        .allowIfBaseType("java.math")
+                        .allowIfBaseType("java.time")
+                        .allowIfSubType("java.lang")
+                        .allowIfSubType("me.rentsignal")
+                        .allowIfSubType("java.util")
+                        .allowIfSubType("java.math")
+                        .allowIfSubType("java.time")
+                        .allowIfSubType("java.lang")
+                        .build();
+
+        // 객체 타입 정보 함께 저장
+        objectMapper.activateDefaultTyping(
+                typeValidator,
+                ObjectMapper.DefaultTyping.EVERYTHING,
+                JsonTypeInfo.As.PROPERTY // 타입 정보를 JSON property로 저장
+        );
+
+
+        // 캐시값을 JSON 형태로 직렬화/역직렬화
+        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(valueSerializer)
+                )
+                .entryTtl(Duration.ofHours(2))
+                .disableCachingNullValues();
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config).build();
+    }
+
+}

--- a/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
+++ b/src/main/java/me/rentsignal/locationInfo/controller/LocationLivingFactorController.java
@@ -28,7 +28,7 @@ public class LocationLivingFactorController {
     }
 
     @GetMapping("/convenience/{neighborhoodId}")
-    public ResponseEntity<?> getConvenienceRanking(@PathVariable Long neighborhoodId) {
+    public ResponseEntity<?> getConvenienceTypeCount(@PathVariable Long neighborhoodId) {
         ConvenienceTypeCountDto convenienceTypeCount = convenienceService.getConvenienceTypeCount(neighborhoodId);
         return ResponseEntity.ok().body(BaseResponse.success(convenienceTypeCount));
     }

--- a/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConsumerSentimentIndexService.java
@@ -6,12 +6,12 @@ import me.rentsignal.locationInfo.entity.ProvinceIndex;
 import me.rentsignal.locationInfo.repository.ProvinceIndexRepository;
 import me.rentsignal.locationInfo.type.PeriodType;
 import me.rentsignal.locationInfo.util.YearMonthUtils;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +23,7 @@ public class ConsumerSentimentIndexService {
     private final LocationInfoService locationInfoService;
 
     // 현재는 서울특별시 데이터만 반환
+    @Cacheable(value = "consumer-sentiment-index", key = "#periodType")
     public ConsumerSentimentIndexDto getConsumerSentimentIndex(PeriodType periodType) {
         // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
         String baseYearMonthText = provinceIndexRepository.findLatestBaseYearMonth();

--- a/src/main/java/me/rentsignal/locationInfo/service/ConvenienceService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/ConvenienceService.java
@@ -10,6 +10,7 @@ import me.rentsignal.locationInfo.dto.ConvenienceTypeCountDto;
 import me.rentsignal.locationInfo.dto.NeighborhoodConvenienceQueryDto;
 import me.rentsignal.locationInfo.entity.ConvenienceType;
 import me.rentsignal.locationInfo.repository.NeighborhoodConvenienceRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -23,6 +24,7 @@ public class ConvenienceService {
     private final NeighborhoodConvenienceRepository neighborhoodConvenienceRepository;
     private final NeighborhoodRepository neighborhoodRepository;
 
+    @Cacheable(value = "convenience-ranking")
     public ConvenienceRankDto getConvenienceRanking() {
         List<NeighborhoodConvenienceQueryDto> topNeighborhoodConvenienceCount = neighborhoodConvenienceRepository.findTopNeighborhoodConvenienceCount(PageRequest.of(0, 7));
 
@@ -45,6 +47,7 @@ public class ConvenienceService {
         return new ConvenienceRankDto(ranking);
     }
 
+    @Cacheable(value = "neighborhood-convenience", key = "#neighborhoodId")
     public ConvenienceTypeCountDto getConvenienceTypeCount(Long neighborhoodId) {
         Neighborhood neighborhood = neighborhoodRepository.findById(neighborhoodId).orElseThrow(
                 () -> new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 id의 읍/면/동이 존재하지 않습니다."));

--- a/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/RentIndexService.java
@@ -11,6 +11,7 @@ import me.rentsignal.locationInfo.entity.RegionIndex;
 import me.rentsignal.locationInfo.repository.RegionIndexRepository;
 import me.rentsignal.locationInfo.type.PeriodType;
 import me.rentsignal.locationInfo.util.YearMonthUtils;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -29,6 +30,7 @@ public class RentIndexService {
     private final RegionIndexRepository regionIndexRepository;
     private final LocationInfoService locationInfoService;
 
+    @Cacheable(value = "current-rent-index", key = "#housingType")
     public CurrentRentIndexDto getCurrentRentIndex(HousingType housingType) {
         // 데이터가 1개월 지연되어 제공되기 때문에 1개월 전 데이터 사용
         String baseYearMonth = regionIndexRepository.findLatestBaseYearMonth();
@@ -50,6 +52,7 @@ public class RentIndexService {
         return new CurrentRentIndexDto(list);
     }
 
+    @Cacheable(value = "previous-rent-index", key = "#housingType + ':' + #periodType")
     public RentIndexChangeDto getRentIndexChange(HousingType housingType, PeriodType periodType) {
         String baseYearMonthText = regionIndexRepository.findLatestBaseYearMonth();
         YearMonth baseYearMonth = YearMonthUtils.toYearMonth(baseYearMonthText);

--- a/src/main/java/me/rentsignal/locationInfo/service/SafetyService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SafetyService.java
@@ -5,6 +5,7 @@ import me.rentsignal.locationInfo.dto.DistrictSafetyDto;
 import me.rentsignal.locationInfo.dto.RankItemDto;
 import me.rentsignal.locationInfo.entity.DistrictSafety;
 import me.rentsignal.locationInfo.repository.DistrictSafetyRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -18,6 +19,7 @@ public class SafetyService {
 
     private final DistrictSafetyRepository districtSafetyRepository;
 
+    @Cacheable(value = "safety")
     public DistrictSafetyDto getSafety() {
         List<DistrictSafety> districtSafetyList = districtSafetyRepository.findByDistrict_Province_NameOrderBySafetyScoreDesc("서울특별시");
 

--- a/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/SubwayAccessibilityIndexService.java
@@ -15,12 +15,12 @@ import me.rentsignal.locationInfo.entity.TransportType;
 import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
 import me.rentsignal.locationInfo.repository.NeighborhoodTransportRepository;
 import me.rentsignal.locationInfo.util.YearMonthUtils;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +35,7 @@ public class SubwayAccessibilityIndexService {
     private final DistrictRepository districtRepository;
     private final NeighborhoodTransportRepository neighborhoodTransportRepository;
 
+    @Cacheable(value = "subway-accessibility-index")
     public SubwayAccessibilityIndexDto getSubwayAccessibilityIndex() {
         // 데이터가 2개월 지연되어 제공되기 때문에 2개월 전 데이터 사용
         String base = districtIndexRepository.findLatestBaseYearMonth();
@@ -109,6 +110,7 @@ public class SubwayAccessibilityIndexService {
         );
     }
 
+    @Cacheable(value = "district-subway-station", key = "#districtId")
     public DistrictSubwayDto getSubwayStationByDistrict(Long districtId) {
         District district = districtRepository.findById(districtId).orElseThrow(
                 () -> new BaseException(ErrorCode.DISTRICT_NOT_FOUND, "해당 id의 시/군/구가 존재하지 않습니다."));

--- a/src/main/java/me/rentsignal/locationInfo/service/TransportService.java
+++ b/src/main/java/me/rentsignal/locationInfo/service/TransportService.java
@@ -15,6 +15,7 @@ import me.rentsignal.locationInfo.entity.TransportType;
 import me.rentsignal.locationInfo.repository.NeighborhoodTransportRepository;
 import me.rentsignal.locationInfo.repository.SubwayTravelTimeRepository;
 import me.rentsignal.locationInfo.type.BusinessDistrictType;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -32,6 +33,7 @@ public class TransportService {
     private final NeighborhoodRepository neighborhoodRepository;
 
     /** 환승 제외 주요 업무지구까지 20분 이내 소요되는 지하철역 조회 */
+    @Cacheable(value = "business-district-neighborhood", key = "#businessDistrictType")
     public List<RecommendedNeighborhoodByBusinessDistrict> getRecommendedNeighborhoodByBusinessDistrict(BusinessDistrictType businessDistrictType) {
         String neighborhoodTransportName = convertToNeighborhoodTransportName(businessDistrictType);
         String[] names = neighborhoodTransportName.split(",");
@@ -221,6 +223,7 @@ public class TransportService {
             int seconds
     ) {}
 
+    @Cacheable(value = "neighborhood=transport", key = "#neighborhoodId")
     public NeighborhoodTransportDto getNeighborhoodTransport(Long neighborhoodId) {
         Neighborhood neighborhood = neighborhoodRepository.findById(neighborhoodId).orElseThrow(
                 () -> new BaseException(ErrorCode.NEIGHBORHOOD_NOT_FOUND, "해당 id의 읍/면/동이 존재하지 않습니다."));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,11 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+    cache:
+      type: redis


### PR DESCRIPTION
## ✅ 관련 이슈
closed #60

## ✨ 작업 내용
### Redis 캐시 적용
**[기존]**
- 매 요청마다 DB를 직접 조회하여 응답
- 동일한 데이터 반복 조회 시에도 DB 쿼리 계속 발생
- 이전 데이터 대비 증감률 계산, 역간 최단 소요시간 계산 등 복잡한 로직 반복 실행

**[개선 이유]**
- API의 응답 속도를 개선하고 DB 부하를 줄이기 위함
- 동일한 결과를 반환하는 반복 로직 실행 최소화하기 위함

**[개선]**

Redis 기반 캐시 적용
- 캐시 TTL은 2시간으로 설정
- Redis에서 데이터 조회 시 객체가 LinkedHashMap 형태로 역직렬화됨으로써 역직렬화 오류 (class java.util.LinkedHashMap cannot be cast to class ...DTO)가 발생함 -> `objectMapper.acitvateDefaultTyping()` 설정을 추가하여 DTO 타입 정보 함께 저장하도록 설정
- 데이터 조회 시 BigDecimal, Long 등의 타입 역직렬화 오류가 발생함 -> BasicPolymorphicTypeValidator에 java.math, java.lang 등의 패키지를 허용하도록 설정 

## 📸 스크린샷


## 🗨️ 참고 사항
Redis 사용 시 아래 명령어를 터미널에 입력해서 Redis 컨테이너를 실행해주세요!
```
docker run --name redis -p 6379:6379 -d redis
```