### PR TITLE
[Feat] 홈 지하철 랭킹 응답에 districtId 추가

### DIFF
--- a/src/main/java/me/rentsignal/home/controller/HomeController.java
+++ b/src/main/java/me/rentsignal/home/controller/HomeController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import me.rentsignal.community.dto.PostListItemResponse;
 import me.rentsignal.global.response.BaseResponse;
 import me.rentsignal.home.service.HomeService;
-import me.rentsignal.locationInfo.dto.RankItemDto;
+import me.rentsignal.home.dto.HomeSubwayRankingResponse;
 import me.rentsignal.recommendation.dto.RecommendResponseDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +30,7 @@ public class HomeController {
     }
 
     @GetMapping("/subway-accessibility-ranking")
-    public BaseResponse<List<RankItemDto>> getSubwayAccessibilityRanking() {
+    public BaseResponse<List<HomeSubwayRankingResponse>> getSubwayAccessibilityRanking() {
         return BaseResponse.success(homeService.getSubwayAccessibilityRanking());
     }
 }

--- a/src/main/java/me/rentsignal/home/dto/HomeSubwayRankingResponse.java
+++ b/src/main/java/me/rentsignal/home/dto/HomeSubwayRankingResponse.java
@@ -1,0 +1,14 @@
+package me.rentsignal.home.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HomeSubwayRankingResponse {
+
+    private Integer rank;
+    private Long districtId;
+    private String name;
+    private Double value;
+}

--- a/src/main/java/me/rentsignal/home/service/HomeService.java
+++ b/src/main/java/me/rentsignal/home/service/HomeService.java
@@ -3,7 +3,6 @@ package me.rentsignal.home.service;
 import lombok.RequiredArgsConstructor;
 import me.rentsignal.community.dto.PostListItemResponse;
 import me.rentsignal.community.repository.PostRepository;
-import me.rentsignal.locationInfo.dto.RankItemDto;
 import me.rentsignal.locationInfo.entity.DistrictIndex;
 import me.rentsignal.locationInfo.repository.DistrictIndexRepository;
 import me.rentsignal.recommendation.dto.RecommendRequestDto;
@@ -11,6 +10,7 @@ import me.rentsignal.recommendation.dto.RecommendResponseDto;
 import me.rentsignal.recommendation.service.RecommendationService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import me.rentsignal.home.dto.HomeSubwayRankingResponse;
 
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ public class HomeService {
                 .getRecommendedNeighborhoods();
     }
 
-    public List<RankItemDto> getSubwayAccessibilityRanking() {
+    public List<HomeSubwayRankingResponse> getSubwayAccessibilityRanking() {
         String baseYearMonth = districtIndexRepository.findLatestBaseYearMonth();
 
         List<DistrictIndex> indexes = districtIndexRepository
@@ -50,15 +50,18 @@ public class HomeService {
                         baseYearMonth
                 );
 
-        List<RankItemDto> ranking = new ArrayList<>();
+        List<HomeSubwayRankingResponse> ranking = new ArrayList<>();
 
         for (int i = 0; i < Math.min(5, indexes.size()); i++) {
             DistrictIndex index = indexes.get(i);
 
-            ranking.add(new RankItemDto(
+            ranking.add(new HomeSubwayRankingResponse(
                     i + 1,
+                    index.getDistrict().getId(),
                     index.getDistrict().getName(),
-                    index.getSubwayAccessibilityIndex().setScale(1, RoundingMode.HALF_UP)
+                    index.getSubwayAccessibilityIndex()
+                            .setScale(1, RoundingMode.HALF_UP)
+                            .doubleValue()
             ));
         }
 


### PR DESCRIPTION
## ✅ 관련 이슈
#62 

## ✨ 작업 내용
- HomeSubwayRankingResponse DTO 추가
- districtId 필드 반환 지원
- 공용 RankItemDto 영향 없이 홈 API 응답 구조 분리
- HomeService/HomeController 응답 타입 변경

## 📸 스크린샷


## 🗨️ 참고 사항
